### PR TITLE
chore: use tedge-main by default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,7 +81,6 @@ jobs:
 
       - name: Start demo
         run: |
-          export DOCKER_USER="1000:101"
           just start -d
 
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG TEDGE_TAG=1.2.0
+ARG TEDGE_TAG=1.2.1-134-ge4ff79b
 # thin-edge.io base image name: tedge, tedge-main
-ARG TEDGE_IMAGE=tedge
+ARG TEDGE_IMAGE=tedge-main
 FROM ghcr.io/thin-edge/${TEDGE_IMAGE}:${TEDGE_TAG}
 ARG TARGETPLATFORM
 ARG S6_OVERLAY_VERSION=3.2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,4 +87,6 @@ ENV TEDGE_C8Y_PROXY_CLIENT_HOST=127.0.0.1
 VOLUME [ "/etc/tedge/device-certs" ]
 
 USER "tedge"
-ENTRYPOINT ["/init"]
+# Allow users to re-use the container for one-off commands
+# to ensure the thin-edge.io version remains the same
+CMD [ "/init" ]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,45 @@ After the project pre-requisites have been installed, you can start the containe
     just run-container
     ```
 
+## Manually deploying
+
+### Using docker and a manually created volume
+
+1. Create a docker volume which will be used to store the device certificate
+
+    ```sh
+    docker volume create device-certs
+    ```
+
+2. Initialize the certificate
+
+    ```sh
+    docker run --rm -it \
+        -v "device-certs:/etc/tedge/device-certs" \
+        -e "TEDGE_C8Y_URL=${C8Y_DOMAIN}" \
+        ghcr.io/thin-edge/tedge-main:latest tedge cert create --device-id "<mydeviceid>"
+    ```
+
+3. Upload the certificate
+
+    ```sh
+    docker run --rm -it \
+        -v "device-certs:/etc/tedge/device-certs" \
+        -e "TEDGE_C8Y_URL=$C8Y_DOMAIN" \
+        -e "C8Y_USER=$C8Y_USER" \
+        -e "C8Y_PASSWORD=$C8Y_PASSWORD" \
+        ghcr.io/thin-edge/tedge-main:latest tedge cert upload c8y
+    ```
+
+4. Start the container
+
+    ```sh
+    docker run --rm -it \
+        -v "device-certs:/etc/tedge/device-certs" \
+        -e "TEDGE_C8Y_URL=$C8Y_DOMAIN" \
+        ghcr.io/thin-edge/tedge-container-bundle:latest
+    ```
+
 ## Project structure
 
 |Directory|Description|

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,16 +4,9 @@ services:
       dockerfile: Dockerfile
       context: .
     restart: always
-    user: "${DOCKER_USER:-tedge:tedge}"
     secrets:
       - source: certificate_private_key
-        mode: 0644
-        uid: "tedge"
-        gid: "tedge"
       - source: certificate_public_key
-        mode: 0644
-        uid: "tedge"
-        gid: "tedge"
     env_file:
       - .env
     tmpfs:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,17 +4,14 @@ services:
       dockerfile: Dockerfile
       context: .
     restart: always
-    secrets:
-      - source: certificate_private_key
-      - source: certificate_public_key
     env_file:
       - .env
     tmpfs:
       - /tmp
+    volumes:
+      - device_certs:/etc/tedge/device-certs
 
-secrets:
-  certificate_private_key:
-    file: device-certs/tedge-private-key.pem
-
-  certificate_public_key:
-    file: device-certs/tedge-certificate.pem
+volumes:
+  device_certs:
+    external:
+      name: device-certs

--- a/scripts/manage.sh
+++ b/scripts/manage.sh
@@ -35,7 +35,7 @@ create_cert() {
 upload() {
     docker run $DOCKER_OPTIONS \
         -v "$VOLUME:/etc/tedge/device-certs" \
-        -e "TEDGE_C8Y_URL=$C8Y_DOMAIN" \
+        -e "TEDGE_C8Y_URL=${TEDGE_C8Y_URL:-$C8Y_DOMAIN}" \
         -e "C8Y_USER=$C8Y_USER" \
         -e "C8Y_PASSWORD=$C8Y_PASSWORD" \
         ghcr.io/thin-edge/tedge:latest tedge cert upload c8y


### PR DESCRIPTION
Until 1.3.0 is released, use tedge-main by default.