### PR TITLE
feat: disable oci images for improved compatibility

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,8 +36,10 @@ build-setup:
 # Example:
 #    just build registry latest
 #    just build registry 1.2.0
+# Use oci-mediatypes=false to improve compatibility with older docker verions, e.g. <= 19.0.x
+# See https://github.com/docker/buildx/issues/1964#issuecomment-1644634461
 build OUTPUT_TYPE=DEFAULT_OUTPUT_TYPE VERSION='latest': build-setup
-    docker buildx build --platform linux/arm/v6,linux/arm/v7,linux/amd64,linux/arm64 --build-arg "TEDGE_IMAGE={{TEDGE_IMAGE}}" --build-arg "TEDGE_TAG={{TEDGE_TAG}}" -t "{{REGISTRY}}/{{REPO_OWNER}}/{{IMAGE}}:{{VERSION}}" -t "{{REGISTRY}}/{{REPO_OWNER}}/{{IMAGE}}:latest" -f Dockerfile --output=type="{{OUTPUT_TYPE}}" .
+    docker buildx build --platform linux/arm/v6,linux/arm/v7,linux/amd64,linux/arm64 --build-arg "TEDGE_IMAGE={{TEDGE_IMAGE}}" --build-arg "TEDGE_TAG={{TEDGE_TAG}}" -t "{{REGISTRY}}/{{REPO_OWNER}}/{{IMAGE}}:{{VERSION}}" -t "{{REGISTRY}}/{{REPO_OWNER}}/{{IMAGE}}:latest" -f Dockerfile --output=type="{{OUTPUT_TYPE}}",oci-mediatypes=false .
 
 # Install python virtual environment
 venv:


### PR DESCRIPTION
Older docker versions, e.g. docker 18.x and some early 19.x versions don't support the newer oci media type, and result in the following error when pulling the image:

```
docker: mediaType in manifest should be 'application/vnd.docker.distribution.manifest.v2+json' not 'application/vnd.oci.image.manifest.v1+json'
```