### PR TITLE
fix: remove temp s6-overlay installation files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ RUN case ${TARGETPLATFORM} in \
     && curl https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz -L -s --output /tmp/s6-overlay-noarch.tar.xz \
     && tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
     && curl https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz -L -s --output /tmp/s6-overlay-${S6_ARCH}.tar.xz \
-    && tar -C / -Jxpf /tmp/s6-overlay-${S6_ARCH}.tar.xz
+    && tar -C / -Jxpf /tmp/s6-overlay-${S6_ARCH}.tar.xz \
+    && rm -f /tmp/s6-overlay-noarch.tar.xz \
+    && rm -f /tmp/s6-overlay-${S6_ARCH}.tar.xz
 
 # Add custom service definitions (e.g. s6-overlay) and community plugins
 RUN rm -f /etc/tedge/system.toml


### PR DESCRIPTION
Remove temporary files left over from the s6-overlay installation