### PR TITLE
fix: initialize the c8y-remote-access-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ RUN wget -O - https://thin-edge.io/install-services.sh | sh -s -- s6_overlay \
 
 # Set permissions of all files under /etc/tedge
 # TODO: Can thin-edge.io set permissions during installation?
-RUN chown -R tedge:tedge /etc/tedge
+RUN chown -R tedge:tedge /etc/tedge \
+    # FIXME: Remove once https://github.com/thin-edge/thin-edge.io/pull/3120 is merged
+    && c8y-remote-access-plugin --init
 
 # Custom init. scripts - e.g. write env variables data to files
 COPY cont-init.d/*  /etc/cont-init.d/


### PR DESCRIPTION
Initialize the c8y-remote-access-plugin until the upstream PR is merged: https://github.com/thin-edge/thin-edge.io/pull/3120