### PR TITLE
fix example in readme (--rm and --restart conflicting options)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Before you can start the containers, you need to create a device certificate ins
 Once the device certificate has been created inside the named volume, the same volume can be used when starting the container.
 
 ```sh
-docker run --rm -it --dns 8.8.8.8 --network host \
+docker run --dns 8.8.8.8 --network host \
+    -d \
     --restart=always \
     -v "device-certs:/etc/tedge/device-certs" \
     -v "mosquitto:/mosquitto/data" \


### PR DESCRIPTION
Updated instructions to run the container in README. Docker reported for the existing one `docker: Conflicting options: --restart and --rm.` 