### PR TITLE
feat: remove gnu sed dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN apk add --no-cache \
         jq \
         bash \
         curl \
-        # GNU sed (to provide the unbuffered streaming option used in the log parsing)
-        sed \
         sudo
 
 # Install s6-overlay


### PR DESCRIPTION
Update thin-edge.io s6-overlay service definitions which no longer requires gnu sed logging purposes.