### PR TITLE
feat: launch remote-access session in separate container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ COPY files/mosquitto/mosquitto.conf /etc/mosquitto/mosquitto.conf
 # Add custom thin-edge.io configuration (e.g. plugin config)
 COPY files/tedge/tedge.toml /etc/tedge/
 COPY files/tedge/plugins/*.toml /etc/tedge/plugins/
+COPY files/tedge/c8y_RemoteAccessConnect /etc/tedge/operations/c8y/
+COPY files/tedge/c8y_RemoteAccessConnect /etc/tedge/operations/c8y/
+COPY files/tedge/launch-remote-access.sh /usr/bin/
 # Self update workflow
 COPY files/tedge/self.sh /etc/tedge/sm-plugins/self
 COPY files/tedge/software_update.toml /etc/tedge/operations/

--- a/files/tedge/c8y_RemoteAccessConnect
+++ b/files/tedge/c8y_RemoteAccessConnect
@@ -1,0 +1,4 @@
+[exec]
+command = "launch-remote-access.sh"
+topic = "c8y/s/ds"
+on_message = "530"

--- a/files/tedge/launch-remote-access.sh
+++ b/files/tedge/launch-remote-access.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+DOCKER_CMD=docker
+if ! docker ps >/dev/null 2>&1; then
+    if command -V sudo >/dev/null 2>&1; then
+        DOCKER_CMD="sudo docker"
+    fi
+fi
+
+CONTAINER_NAME=${CONTAINER_NAME:-}
+if [ -z "$CONTAINER_NAME" ]; then
+    CONTAINER_NAME=$(hostname)
+fi
+CONTAINER_ID=$($DOCKER_CMD inspect "$CONTAINER_NAME" --format "{{.Id}}")
+
+# use the same image as the current container
+IMAGE=$($DOCKER_CMD inspect "$CONTAINER_ID" --format "{{.Config.Image}}")
+
+# Inherit docker flags
+# Note: The single quotes around 'EOT' prevents variable expansion
+TEMPLATE=$(
+    cat <<'EOT'
+  {{- with .HostConfig}}
+        {{- range $e := .ExtraHosts}}
+  --add-host {{printf "%q" $e}} \
+        {{- end}}
+    {{- end}}
+  {{- with .NetworkSettings -}}
+        {{- range $n, $conf := .Networks}}
+            {{- with $conf }}
+  --network {{printf "%q" $n}} \
+                {{- range $a := $conf.Aliases}} 
+  --network-alias {{printf "%q" $a}} \
+                {{- end}}
+            {{- end}}
+        {{- end}}
+    {{- end}}
+EOT
+)
+OPTIONS=$($DOCKER_CMD inspect "$CONTAINER_ID" --format "$TEMPLATE" | tr -d "\n\\\"")
+
+TEDGE_C8Y_URL=$(tedge config get c8y.url)
+
+# Launch an independent container to handle the remote access session
+# so that it can do things like restarting this container
+# shellcheck disable=SC2086
+$DOCKER_CMD run --rm -d \
+    $OPTIONS \
+    -e TEDGE_MQTT_CLIENT_HOST="$CONTAINER_NAME" \
+    -e TEDGE_C8Y_URL="$TEDGE_C8Y_URL" \
+    "$IMAGE" \
+    c8y-remote-access-plugin --child "$@"

--- a/files/tedge/launch-remote-access.sh
+++ b/files/tedge/launch-remote-access.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -e
 
+if ! command -V docker >/dev/null 2>&1 || [ ! -e /var/run/docker.sock ]; then
+    echo "Launching session as a child process"
+    c8y-remote-access-plugin "$@"
+    exit 0
+fi
+
+echo "Launching session in an independent container"
 DOCKER_CMD=docker
 if ! docker ps >/dev/null 2>&1; then
     if command -V sudo >/dev/null 2>&1; then


### PR DESCRIPTION
Launching in the background enables the session to be independent of the parent container. This opens up the possibility to perform maintaince/updates on the parent container in the ssh session.