### PR TITLE
feat(self-update): use docker template to generate docker run options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ COPY files/tedge/self.sh /etc/tedge/sm-plugins/self
 COPY files/tedge/software_update.toml /etc/tedge/operations/
 COPY files/tedge/self_update.toml /etc/tedge/operations/
 COPY files/tedge/self_update.sh /usr/bin/
+COPY files/tedge/container_run.tpl /usr/share/tedge/
 
 
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2

--- a/files/tedge/container_run.tpl
+++ b/files/tedge/container_run.tpl
@@ -1,0 +1,124 @@
+{{/*
+    golang template to build the docker run options using `docker inspect <container> --format "container_run.tpl"`
+    Credit: https://gist.github.com/efrecon/8ce9c75d518b6eb863f667442d7bc679
+*/}}
+  --name {{printf "%q" .Name}} \
+    {{- with .HostConfig}}
+        {{- if .Privileged}}
+  --privileged \
+        {{- end}}
+        {{- range $b := .Binds}}
+  --volume {{printf "%q" $b}} \
+        {{- end}}
+        {{- range $v := .VolumesFrom}}
+  --volumes-from {{printf "%q" $v}} \
+        {{- end}}
+        {{- range $l := .Links}}
+  --link {{printf "%q" $l}} \
+        {{- end}}
+        {{- if index . "Mounts"}}
+            {{- range $m := .Mounts}}
+  --mount type={{.Type}}
+                {{- if $s := index $m "Source"}},source={{$s}}{{- end}}
+                {{- if $t := index $m "Target"}},destination={{$t}}{{- end}}
+                {{- if index $m "ReadOnly"}},readonly{{- end}}
+                {{- if $vo := index $m "VolumeOptions"}}
+                    {{- range $i, $v := $vo.Labels}}
+                        {{- printf ",volume-label=%s=%s" $i $v}}
+                    {{- end}}
+                    {{- if $dc := index $vo "DriverConfig" }}
+                        {{- if $n := index $dc "Name" }}
+                            {{- printf ",volume-driver=%s" $n}}
+                        {{- end}}
+                        {{- range $i, $v := $dc.Options}}
+                            {{- printf ",volume-opt=%s=%s" $i $v}}
+                        {{- end}}
+                    {{- end}}
+                {{- end}}
+                {{- if $bo := index $m "BindOptions"}}
+                    {{- if $p := index $bo "Propagation" }}
+                        {{- printf ",bind-propagation=%s" $p}}
+                    {{- end}}
+                {{- end}} \
+            {{- end}}
+        {{- end}}
+        {{- if .PublishAllPorts}}
+  --publish-all \
+        {{- end}}
+        {{- if .UTSMode}}
+  --uts {{printf "%q" .UTSMode}} \
+        {{- end}}
+  --restart always \
+        {{- range $e := .ExtraHosts}}
+  --add-host {{printf "%q" $e}} \
+        {{- end}}
+        {{- range $v := .CapAdd}}
+  --cap-add {{printf "%q" $v}} \
+        {{- end}}
+        {{- range $v := .CapDrop}}
+  --cap-drop {{printf "%q" $v}} \
+        {{- end}}
+        {{- range $d := .Devices}}
+  --device {{printf "%q" (index $d).PathOnHost}}:{{printf "%q" (index $d).PathInContainer}}:{{(index $d).CgroupPermissions}} \
+        {{- end}}
+    {{- end}}
+    {{- with .NetworkSettings -}}
+        {{- range $p, $conf := .Ports}}
+            {{- with $conf}}
+  --publish "
+                {{- if $h := (index $conf 0).HostIp}}{{$h}}:
+                {{- end}}
+                {{- (index $conf 0).HostPort}}:{{$p}}" \
+            {{- end}}
+        {{- end}}
+        {{- range $n, $conf := .Networks}}
+            {{- with $conf}}
+  --network {{printf "%q" $n}} \
+                {{- range $a := $conf.Aliases}}
+  --network-alias {{printf "%q" $a}} \
+                {{- end}}
+            {{- end}}
+        {{- end}}
+    {{- end}}
+    {{- with .Config}}
+        {{- if .Domainname}}
+  --domainname {{printf "%q" .Domainname}} \
+        {{- end}}
+        {{- if index . "ExposedPorts"}}
+        {{- range $p, $conf := .ExposedPorts}}
+  --expose {{printf "%q" $p}} \
+        {{- end}}
+        {{- end}}
+        {{- range $e := .Env}}
+  --env {{printf "%q" $e}} \
+        {{- end}}
+        {{- range $l, $v := .Labels}}
+  --label {{printf "%q" $l}}={{printf "%q" $v}} \
+        {{- end}}
+    {{- if .AttachStdin}}
+  --attach stdin \
+    {{- end}}
+    {{- if .AttachStdout}}
+  --attach stdout \
+    {{- end}}
+    {{- if .AttachStderr}}
+  --attach stderr \
+    {{- end}}
+    {{- if .Tty}}
+  --tty \
+    {{- end}}
+    {{- if .OpenStdin}}
+  --interactive \
+    {{- end}}
+    {{- if .Entrypoint}}
+{{- /* Since the entry point cannot be overridden from the command line with an array of size over 1,
+       we are fine assuming the default value in such a case. */ -}}
+        {{- if eq (len .Entrypoint) 1 }}
+  --entrypoint "
+            {{- range $i, $v := .Entrypoint}}
+                {{- if $i}} {{end}}
+                {{- $v}}
+            {{- end}}" \
+        {{- end}}
+    {{- end}}
+{{- end}}

--- a/files/tedge/container_run.tpl
+++ b/files/tedge/container_run.tpl
@@ -92,20 +92,8 @@
         {{- range $l, $v := .Labels}}
   --label {{printf "%q" $l}}={{printf "%q" $v}} \
         {{- end}}
-    {{- if .AttachStdin}}
-  --attach stdin \
-    {{- end}}
-    {{- if .AttachStdout}}
-  --attach stdout \
-    {{- end}}
-    {{- if .AttachStderr}}
-  --attach stderr \
-    {{- end}}
     {{- if .Tty}}
   --tty \
-    {{- end}}
-    {{- if .OpenStdin}}
-  --interactive \
     {{- end}}
     {{- if .Entrypoint}}
 {{- /* Since the entry point cannot be overridden from the command line with an array of size over 1,

--- a/files/tedge/container_run.tpl
+++ b/files/tedge/container_run.tpl
@@ -74,9 +74,6 @@
         {{- range $n, $conf := .Networks}}
             {{- with $conf}}
   --network {{printf "%q" $n}} \
-                {{- range $a := $conf.Aliases}}
-  --network-alias {{printf "%q" $a}} \
-                {{- end}}
             {{- end}}
         {{- end}}
     {{- end}}

--- a/files/tedge/self_update.sh
+++ b/files/tedge/self_update.sh
@@ -279,6 +279,13 @@ rollback() {
     $DOCKER_CMD container rename "$BACKUP_CONTAINER_NAME" "$CONTAINER_NAME"
     $DOCKER_CMD container update "$CONTAINER_NAME" --restart always
     $DOCKER_CMD start "$CONTAINER_NAME" ||:
+
+    log "Performing a healthcheck on the restored container (for information purposes only)"
+    if healthcheck; then
+        log "Rollback was successful and the container is functioning"
+    else
+        log "Rollback was successful but container healthcheck failed, though this could fail if the cloud connectivity is down"
+    fi
 }
 
 publish_message() {

--- a/files/tedge/self_update.sh
+++ b/files/tedge/self_update.sh
@@ -351,7 +351,9 @@ collect_update_logs() {
         fi
 
         log "Collecting updater container logs. name=$UPDATER_CONTAINER_NAME"
+        log "----- Start of updater logs -----"
         $DOCKER_CMD logs "$UPDATER_CONTAINER_NAME" >&2 ||:
+        log "----- End of updater logs -----"
     else
         log "Updater container does not exist so no logs to collect. name=$UPDATER_CONTAINER_NAME"
     fi

--- a/files/tedge/self_update.toml
+++ b/files/tedge/self_update.toml
@@ -13,13 +13,13 @@ action = "proceed"
 on_success = "needs_update"
 
 [needs_update]
-script = "self_update.sh needs_update --image ${.payload.image}"
+script = "self_update.sh needs_update --image ${.payload.image} --container-name ${.payload.containerName}"
 on_exit.0 = "update"
 on_exit.1 = "successful"
 on_exit._ = "failed"
 
 [update]
-script = "self_update.sh update_background --image ${.payload.image}"
+script = "self_update.sh update_background --image ${.payload.image} --container-name ${.payload.containerName}"
 on_success = "restart"
 on_error = "failed"
 
@@ -36,7 +36,7 @@ action = "await-operation-completion"
 on_success = "verify"
 
 [verify]
-script = "self_update.sh verify --image ${.payload.image}"
+script = "self_update.sh verify --image ${.payload.image} --container-name ${.payload.containerName}"
 on_success = "successful"
 on_error = "failed"
 

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -37,10 +37,16 @@ Self update should only update if there is a new image
     # Cumulocity.Device Should Have Event/s    type=tedge_self_update    after=${date}    minimum=0    maximum=0
 
 Self update using software update operation
+    # pre-condition
+    Device Should Have Installed Software
+    ...    {"name": "tedge", "version": "tedge-container-bundle-tedge:.*", "softwareType": "self"}    timeout=10
+
     ${operation}=    Cumulocity.Install Software
     ...    {"name": "tedge", "version": "tedge-container-bundle-tedge-next", "softwareType": "self"}
 
     Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Device Should Have Installed Software
+    ...    {"name": "tedge", "version": "tedge-container-bundle-tedge-next:.*", "softwareType": "self"}
     [Teardown]    Collect Log Files
 
 
@@ -52,6 +58,6 @@ Clear Local Operation
 
 Collect Log Files
     ${operation}=    Cumulocity.Execute Shell Command
-    ...    cat /mosquitto/data/logs/agent/workflow-software*.log | tail -50 || true
+    ...    find /mosquitto/data/logs/agent/ -type f -name "workflow-software_update*.log" -exec ls -t1 {} + | head -1 | xargs tail -c 15000
     ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
     Log    ${operation["c8y_Command"]["result"]}

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -44,7 +44,7 @@ Self update using software update operation
     ${operation}=    Cumulocity.Install Software
     ...    {"name": "tedge", "version": "tedge-container-bundle-tedge-next", "softwareType": "self"}
 
-    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
     Device Should Have Installed Software
     ...    {"name": "tedge", "version": "tedge-container-bundle-tedge-next:.*", "softwareType": "self"}
     [Teardown]    Collect Log Files

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -39,12 +39,9 @@ Self update should only update if there is a new image
 Self update using software update operation
     ${operation}=    Cumulocity.Install Software
     ...    {"name": "tedge", "version": "tedge-container-bundle-tedge-next", "softwareType": "self"}
-    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
 
-    # TODO: Check the status of the operation
-    ${operation}=    Cumulocity.Execute Shell Command
-    ...    cat /mosquitto/data/logs/agent/workflow-software*.log | tail -50 || true
-    ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    [Teardown]    Collect Log Files
 
 
 *** Keywords ***
@@ -52,3 +49,9 @@ Clear Local Operation
     [Arguments]    ${topic}
     ${operation}=    Cumulocity.Execute Shell Command    tedge mqtt pub -r ${topic} ''
     ${operation}=    Cumulocity.Operation Should Be DONE    ${operation}
+
+Collect Log Files
+    ${operation}=    Cumulocity.Execute Shell Command
+    ...    cat /mosquitto/data/logs/agent/workflow-software*.log | tail -50 || true
+    ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Log    ${operation["c8y_Command"]["result"]}


### PR DESCRIPTION
Support transferring more docker run options by using the golang template format which is supported by the `docker inspect <container> --format "<template>"` syntax.

The new template supports transferring more docker run options than previously to ensure the new container is spawned in a very similar manner as the previous container