### PR TITLE
refactor! Change persistence volume name from mosquitto to tedge

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       - /tmp
     volumes:
       - device-certs:/etc/tedge/device-certs
-      - mosquitto:/mosquitto/data
+      - tedge:/data/tedge
       - /var/run/docker.sock:/var/run/docker.sock:rw
     profiles:
       - service
@@ -44,8 +44,8 @@ services:
 volumes:
   device-certs:
     name: device-certs
-  mosquitto:
-    name: mosquitto
+  tedge:
+    name: tedge
 
 networks:
   tedge:

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -9,12 +9,12 @@ services:
       - /tmp
     volumes:
       - device-certs:/etc/tedge/device-certs
-      - mosquitto:/mosquitto/data
+      - tedge:/data/tedge
       # Enable docker from docker
       - /var/run/docker.sock:/var/run/docker.sock:rw
 
 volumes:
   device-certs:
     external: true
-  mosquitto:
+  tedge:
     external: true

--- a/files/mosquitto/mosquitto.conf
+++ b/files/mosquitto/mosquitto.conf
@@ -1,6 +1,6 @@
 ## system settings
 persistence true
-persistence_location /mosquitto/data/
+persistence_location /data/tedge/
 log_dest stdout
 
 include_dir /etc/tedge/mosquitto-conf

--- a/files/tedge/plugins/tedge-log-plugin.toml
+++ b/files/tedge/plugins/tedge-log-plugin.toml
@@ -1,4 +1,4 @@
 files = [
-    { type = "software-management", path = "/mosquitto/data/logs/agent/workflow-software*" },
-    { type = "shell", path = "/mosquitto/data/logs/agent/c8y_Command-*" },
+    { type = "software-management", path = "/data/tedge/logs/agent/workflow-software*" },
+    { type = "shell", path = "/data/tedge/logs/agent/c8y_Command-*" },
 ]

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ run-local: build-local
         --network tedge \
         --tmpfs /tmp \
         -v "device-certs:/etc/tedge/device-certs" \
-        -v "mosquitto:/mosquitto/data" \
+        -v "tedge:/data/tedge" \
         -v /var/run/docker.sock:/var/run/docker.sock:rw \
         -e "TEDGE_C8Y_URL=$TEDGE_C8Y_URL" \
         tedge-container-bundle-tedge

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -19,7 +19,7 @@ Trigger self update via local command
 
     # TODO: Check the status of the operation
     ${operation}=    Cumulocity.Execute Shell Command
-    ...    cat /mosquitto/data/logs/agent/workflow-self_update-local-*.log ${topic} | tail -n50 || true
+    ...    cat /data/tedge/logs/agent/workflow-self_update-local-*.log ${topic} | tail -n50 || true
 
     ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
 
@@ -58,6 +58,6 @@ Clear Local Operation
 
 Collect Log Files
     ${operation}=    Cumulocity.Execute Shell Command
-    ...    find /mosquitto/data/logs/agent/ -type f -name "workflow-software_update*.log" -exec ls -t1 {} + | head -1 | xargs tail -c 15000
+    ...    find /data/tedge/logs/agent/ -type f -name "workflow-software_update*.log" -exec ls -t1 {} + | head -1 | xargs tail -c 15000
     ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
     Log    ${operation["c8y_Command"]["result"]}


### PR DESCRIPTION
:boom: Breaking change!

Change the data persistence path and name from `/mosquitto/data` to `/data/tedge` as the volume was being used to store both mosquitto and tedge data, and using tedge aligns with naming convention used on physical devices that have firmware_update support.