### PR TITLE
feat(self-update): collect logs from unhealthy container before removing it

### DIFF
--- a/files/tedge/self_update.sh
+++ b/files/tedge/self_update.sh
@@ -275,6 +275,11 @@ rollback() {
 
     log "Stopping unhealthy container. name=$CONTAINER_NAME"
     $DOCKER_CMD stop "$CONTAINER_NAME" ||:
+
+    log "Collecting logs from the unhealthy container. name=$CONTAINER_NAME"
+    log "----- Start of unhealthy container logs -----"
+    $DOCKER_CMD logs "$CONTAINER_NAME" -n 500 >&2 ||:
+    log "----- End of unhealthy container logs -----"
     $DOCKER_CMD rm "$CONTAINER_NAME" ||:
 
     log "Restoring container from backup. name=$BACKUP_CONTAINER_NAME (new name will be $CONTAINER_NAME)"


### PR DESCRIPTION
When an update fails and the container is rolledback, collect the logs from the failed container to make it easier to debug why it failed.