### PR TITLE
feat(self-update): improve healthcheck and updater log file collection

### DIFF
--- a/files/tedge/self_update.sh
+++ b/files/tedge/self_update.sh
@@ -361,7 +361,7 @@ collect_update_logs() {
 
         log "Collecting updater container logs. name=$UPDATER_CONTAINER_NAME"
         log "----- Start of updater logs -----"
-        $DOCKER_CMD logs "$UPDATER_CONTAINER_NAME" >&2 ||:
+        $DOCKER_CMD logs "$UPDATER_CONTAINER_NAME" -n 500 >&2 ||:
         log "----- End of updater logs -----"
     else
         log "Updater container does not exist so no logs to collect. name=$UPDATER_CONTAINER_NAME"

--- a/files/tedge/self_update.sh
+++ b/files/tedge/self_update.sh
@@ -258,7 +258,7 @@ healthcheck() {
             break
         fi
         ATTEMPT=$((ATTEMPT+1))
-        sleep 1
+        sleep 10
     done
 
     return "$TIMED_OUT"


### PR DESCRIPTION
Robustness improvements for failed updates:

* Only collect last 500 lines of the updater log to prevent cases where the updater produces a large number of log lines
* Increase the delay on failed health checks before retrying to give the container a chance to initialize and connect to the cloud