### PR TITLE
chore: bump tedge version to 1.3.1

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ set dotenv-load
 
 IMAGE := "tedge-container-bundle"
 TEDGE_IMAGE := "tedge"
-TEDGE_TAG := "1.3.0"
+TEDGE_TAG := "1.3.1"
 TAG := "latest"
 ENV_FILE := ".env"
 


### PR DESCRIPTION
Update to thin-edge.io 1.3.1