### PR TITLE
feat: support loading device certificate from multiple locations (env, secrets, file)

### DIFF
--- a/cont-init.d/50_configure.sh
+++ b/cont-init.d/50_configure.sh
@@ -3,24 +3,75 @@
 set -e
 echo "Current User: $(whoami)"
 
+#
+# device certificate loaders
+#
+load_from_env() {
+    #
+    # Load certificate (base64 encoded) from env variables
+    #
+    if [ -z "${CERTPRIVATE:-}" ] || [ -z "${CERTPUBLIC:-}" ]; then
+        return 1
+    fi
+    echo "Loading device certificate from environment variables" >&2
+
+    echo "Writing thin-edge.io private key from env 'CERTPRIVATE' (decoding from base64) to file" >&2
+    CERT_FILE_KEY="$(tedge config get device.key_path)"
+    printf '%s' "$CERTPRIVATE" | tr -d '"' | base64 -d > "$CERT_FILE_KEY"
+    chmod 600 "$CERT_FILE_KEY"
+
+    echo "Writing thin-edge.io private key from env 'CERTPUBLIC' (decoding from base64) to file" >&2
+    CERT_FILE_PUB="$(tedge config get device.cert_path)"
+    printf '%s' "$CERTPUBLIC" | tr -d '"' | base64 -d > "$CERT_FILE_PUB"
+    chmod 644 "$CERT_FILE_PUB"
+}
+
+load_from_secrets() {
+    #
+    # Load certificates from docker secrets, see https://docs.docker.com/reference/cli/docker/secret/create/
+    # Note: Due to permissions problems, copy the secrets from the /run read-only path to /etc/tedge/device-certs/
+    #
+    if [ ! -f /run/secrets/certificate_private_key ] || [ ! -f /run/secrets/certificate_public_key ]; then
+        return 1
+    fi
+
+    echo "Loading device certificate from docker secrets" >&2
+
+    CERT_FILE_KEY="$(tedge config get device.key_path)"
+    cat /run/secrets/certificate_private_key > "$CERT_FILE_KEY"
+    chmod 600 "$CERT_FILE_KEY"
+
+    CERT_FILE_PUB="$(tedge config get device.cert_path)"
+    cat /run/secrets/certificate_public_key > "$CERT_FILE_PUB"
+    chmod 644 "$CERT_FILE_PUB"
+}
+
+load_from_file() {
+    CERT_FILE_KEY="$(tedge config get device.key_path)"
+    CERT_FILE_PUB="$(tedge config get device.cert_path)"
+
+    if [ ! -f "$CERT_FILE_KEY" ] || [ ! -f "$CERT_FILE_PUB" ]; then
+        return 1
+    fi
+
+    # Don't actually do anything, but confirm the presence of device certificates
+    echo "Loading device certifcates from file (no-op)"
+}
+
+############
+# Main
+############
+
 # Create the agent state folder
 AGENT_STATE=$(tedge config get agent.state.path)
 mkdir -p "$AGENT_STATE"
 
 #
-# Note: Due to permissions problems, copy the secrets from the /run read-only path to /etc/tedge/device-certs/
+# Try loading the device certificates from several locations, taking the first successful function
+# Don't fail as users are allowed to start up a container without a device certificate (e.g. when only running the tedge-agent)
 #
-CERT_FILE_KEY="$(tedge config get device.key_path)"
-if [ -f /run/secrets/certificate_private_key ]; then
-    cat /run/secrets/certificate_private_key > "$CERT_FILE_KEY"
-    chmod 600 "$CERT_FILE_KEY"
-fi
+load_from_env || load_from_secrets || load_from_file ||:
 
-CERT_FILE_PUB="$(tedge config get device.cert_path)"
-if [ -f /run/secrets/certificate_public_key ]; then
-    cat /run/secrets/certificate_public_key > "$CERT_FILE_PUB"
-    chmod 644 "$CERT_FILE_PUB"
-fi
 
 # Support variable set by go-c8y-cli
 if [ -n "$C8Y_DOMAIN" ] && [ -z "${TEDGE_C8Y_URL:-}" ]; then


### PR DESCRIPTION
Support loading the device certificate from different sources:

* From base64 encoded environment variables (`CERTPRIVATE` and `CERTPUBLIC`)
* From docker secrets, called `certificate_private_key` and `certificate_public_key`
* From file (e.g. using a volume which contains an already created certificate)

The first found certificate (regardless if it is valid or not) will be taken.