### PR TITLE
docs: update info about where the container is stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ After the project pre-requisites have been installed, you can start the containe
     set-session
     ```
 
-3. Init the device certificate (stored under `./device-cert) and upload it to Cumulocity IoT
+3. Init the device certificate (stored in a container volume) and upload it to Cumulocity IoT
 
     ```sh
     just init


### PR DESCRIPTION
The step incorrectly states that the cert was stored under a host directory instead of a docker volume