### PR TITLE
feat: use tedge-container-plugin-ng to manage containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,12 +50,12 @@ RUN wget -O - https://thin-edge.io/install-services.sh | sh -s -- s6_overlay \
         # might not have access to it
         # Note: Volumes should be configured to persist the docker compose files
         docker-cli-compose \
-        tedge-container-plugin
+        tedge-container-plugin-ng
 
 # Set permissions of all files under /etc/tedge
 # TODO: Can thin-edge.io set permissions during installation?
 RUN chown -R tedge:tedge /etc/tedge \
-    && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /usr/bin/tedgectl, /usr/bin/docker" >/etc/sudoers.d/tedge
+    && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /usr/bin/tedgectl, /usr/bin/docker, /usr/bin/tedge-container" >/etc/sudoers.d/tedge
 # Custom init. scripts - e.g. write env variables data to files
 COPY cont-init.d/*  /etc/cont-init.d/
 
@@ -100,6 +100,7 @@ ENV SERVICE_TEDGE_MAPPER_COLLECTD=0
 
 ENV SERVICE_TEDGE_AGENT=1
 ENV SERVICE_C8Y_FIRMWARE_PLUGIN=0
+ENV SERVICE_TEDGE_CONTAINER_PLUGIN=1
 
 
 # Control thin-edge.io settings via env variables

--- a/tests/main/operations.robot
+++ b/tests/main/operations.robot
@@ -11,6 +11,9 @@ Suite Setup     Set Main Device
 Grace period to allow container to startup
     Sleep    5s    reason=Wait for container to startup
 
+tedge-container-plugin service is up
+    Cumulocity.Should Have Services    name=tedge-container-plugin    status=up    max_count=1
+
 Restart device
     Skip
     ${date_from}=    Get Test Start Time


### PR DESCRIPTION
Use the `tedge-container-plugin-ng` plugin to manage and monitor containers.