### PR TITLE
test: add coverage for service creation after installing a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN wget -O - https://thin-edge.io/install-services.sh | sh -s -- s6_overlay \
 # Set permissions of all files under /etc/tedge
 # TODO: Can thin-edge.io set permissions during installation?
 RUN chown -R tedge:tedge /etc/tedge \
-    && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /usr/bin/tedgectl, /usr/bin/docker, /usr/bin/tedge-container" >/etc/sudoers.d/tedge
+    && echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /usr/bin/tedgectl, /usr/bin/docker, /usr/bin/tedge-container, /bin/kill" >/etc/sudoers.d/tedge
 # Custom init. scripts - e.g. write env variables data to files
 COPY cont-init.d/*  /etc/cont-init.d/
 

--- a/tests/main/operations.robot
+++ b/tests/main/operations.robot
@@ -45,6 +45,7 @@ Install application using docker compose
     ${software}=    Device Should Have Installed Software
     ...    {"name": "nodered-instance1", "version": "1.0.0", "softwareType": "container-group"}
 
+    Cumulocity.Should Have Services    service_type=container-group    name=nodered-instance1@node-red    status=up    max_count=1
 
 Get Container Logs
     ${operation}=    Cumulocity.Get Log File    container    search_text=tedge    maximum_lines=100


### PR DESCRIPTION
Due to a bug in the tedge-container-plugin-ng s6-overlay definition, services representing the containers  wasn't being created due to a permissions problem.

The system test now covers the functionality.