### PR TITLE
fix(self-update): add compatibility script to update from older versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,8 @@ COPY files/tedge/launch-remote-access.sh /usr/bin/
 # Self update workflow
 COPY files/tedge/software_update.toml /etc/tedge/operations/
 COPY files/tedge/self_update.toml /etc/tedge/operations/
+# Self update compatibility script for updating from images <= 20241126.1855
+COPY files/tedge/self_update.sh /usr/bin/
 # Container log_upload customer handler
 COPY files/tedge/container-logs.sh /usr/bin/
 COPY files/tedge/log_upload.toml /etc/tedge/operations/

--- a/files/tedge/self_update.sh
+++ b/files/tedge/self_update.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Compatibility script for updating of images from older versions <= 20241126.1855
+#
+
+#
+# Argument parsing
+#
+ACTION="$1"
+shift
+
+IMAGE=
+CURRENT_CONTAINER_ID=
+
+DOCKER_CMD=docker
+if ! docker ps >/dev/null 2>&1; then
+    if command -V sudo >/dev/null 2>&1; then
+        DOCKER_CMD="sudo docker"
+    fi
+fi
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --image)
+            IMAGE="$2"
+            shift
+            ;;
+        --container-name)
+            # not used
+            shift
+            ;;
+        --container-id)
+            CURRENT_CONTAINER_ID="$2"
+            shift
+            ;;
+    esac
+    shift
+done
+
+case "$ACTION" in
+    update)
+        # In previous images, only docker was supported
+        echo "Calling legacy update script (upgrading from an image <= 20241126.1855)"
+        $DOCKER_CMD run -t --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            "$IMAGE" sudo tedge-container tools container-clone --container "$CURRENT_CONTAINER_ID" --image "$IMAGE"
+        ;;
+esac

--- a/test-images/common/container-bundle.sh
+++ b/test-images/common/container-bundle.sh
@@ -28,7 +28,9 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         --image)
-            IMAGE="$2"
+            if [ -n "$2" ]; then
+                IMAGE="$2"
+            fi
             shift
             ;;
         --debug)

--- a/tests/main/self-update-compat.robot
+++ b/tests/main/self-update-compat.robot
@@ -18,6 +18,13 @@ Upgrade From Base Image
     [Arguments]    ${IMAGE}    ${SOFTWARE_VERSION}
     # pre-condition
     Setup Device    image=${IMAGE}
+
+    ${major_version}=    Execute Command
+    ...    podman --version | cut -d' ' -f3 | cut -d. -f1
+    ...    ignore_exit_code=${True}
+    ...    strip=${True}
+    Skip If    '${major_version}' == '4'    Legacy images didn't support podman 4.x
+
     Device Should Have Installed Software
     ...    {"name": "tedge", "version": "${SOFTWARE_VERSION}", "softwareType": "self"}    timeout=10
 

--- a/tests/main/self-update-compat.robot
+++ b/tests/main/self-update-compat.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Resource            ../resources/common.resource
+Library             DateTime
+
+Test Teardown       Stop Device
+
+Test Tags           self-update
+
+
+*** Test Cases ***
+Update From Legacy Versions
+    [Template]    Upgrade From Base Image
+    ghcr.io/thin-edge/tedge-container-bundle:20241126.1855    tedge-container-bundle:20241126.1855
+
+
+*** Keywords ***
+Upgrade From Base Image
+    [Arguments]    ${IMAGE}    ${SOFTWARE_VERSION}
+    # pre-condition
+    Setup Device    image=${IMAGE}
+    Device Should Have Installed Software
+    ...    {"name": "tedge", "version": "${SOFTWARE_VERSION}", "softwareType": "self"}    timeout=10
+
+    ${operation}=    Cumulocity.Install Software
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}
+
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
+    Device Should Have Installed Software
+    ...    {"name": "tedge", "version": "tedge-container-bundle:99.99.1", "softwareType": "self"}

--- a/tests/resources/common.resource
+++ b/tests/resources/common.resource
@@ -18,11 +18,13 @@ Library     DeviceLibrary    bootstrap_script=/dev/null
 
 *** Keywords ***
 Setup Device
+    [Arguments]    ${image}=
     ${DEVICE_ID}=    DeviceLibrary.Setup    skip_bootstrap=${True}
 
     Transfer To Device    ${CURDIR}/../../test-images/common/container-bundle.sh    /usr/bin/
     Transfer To Device    ${CURDIR}/../*.tar.gz    /build/
-    Execute Command    container-bundle.sh start --device-id '${DEVICE_ID}' --c8y-url '${C8Y_CONFIG.host}' --debug 2>&1
+    Execute Command
+    ...    container-bundle.sh start --device-id '${DEVICE_ID}' --c8y-url '${C8Y_CONFIG.host}' --image "${image}" --debug 2>&1
 
     Set Suite Variable    ${DEVICE_ID}
     Cumulocity.External Identity Should Exist    ${DEVICE_ID}


### PR DESCRIPTION
Add back in the `self_update.sh` script as it is still called when updating from older images to the new one.