### PR TITLE
tests: use full image names in version field

### DIFF
--- a/tests/main/self-update-compat.robot
+++ b/tests/main/self-update-compat.robot
@@ -10,12 +10,12 @@ Test Tags           self-update
 *** Test Cases ***
 Update From Legacy Versions
     [Template]    Upgrade From Base Image
-    ghcr.io/thin-edge/tedge-container-bundle:20241126.1855    tedge-container-bundle:20241126.1855
+    ghcr.io/thin-edge/tedge-container-bundle:20241126.1855
 
 
 *** Keywords ***
 Upgrade From Base Image
-    [Arguments]    ${IMAGE}    ${SOFTWARE_VERSION}
+    [Arguments]    ${IMAGE}
     # pre-condition
     Setup Device    image=${IMAGE}
 
@@ -26,11 +26,11 @@ Upgrade From Base Image
     Skip If    '${major_version}' == '4'    Legacy images didn't support podman 4.x
 
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "${SOFTWARE_VERSION}", "softwareType": "self"}    timeout=10
+    ...    {"name": "tedge", "version": "${IMAGE}", "softwareType": "self"}    timeout=10
 
     ${operation}=    Cumulocity.Install Software
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}
 
     Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "tedge-container-bundle:99.99.1", "softwareType": "self"}
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -35,23 +35,23 @@ Self update should only update if there is a new image
 Self update using software update operation
     # pre-condition
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "tedge-container-bundle:99.99.1", "softwareType": "self"}    timeout=10
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}    timeout=10
 
     ${operation}=    Cumulocity.Install Software
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "self"}
 
     Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "tedge-container-bundle:99.99.2", "softwareType": "self"}
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "self"}
 
 Rollback when trying to install a non-tedge based image
     # pre-condition
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "tedge-container-bundle:99.99.1", "softwareType": "self"}    timeout=10
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}    timeout=10
 
     ${operation}=    Cumulocity.Install Software
     ...    {"name": "tedge", "version": "docker.io/library/alpine:latest", "softwareType": "self"}
 
     Cumulocity.Operation Should Be FAILED    ${operation}    timeout=120
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "tedge-container-bundle:99.99.1", "softwareType": "self"}
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}


### PR DESCRIPTION
Update test to match the tedge-container-plugin-ng 2.0.0~rc24 which now uses the full image name in the `container` sm-plugin version field.