### PR TITLE
feat(self-update): support self update via container sm-plugin type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,9 @@ RUN wget -O - https://thin-edge.io/install-services.sh | sh -s -- s6_overlay \
         # might not have access to it
         # Note: Volumes should be configured to persist the docker compose files
         docker-cli-compose \
-        tedge-container-plugin-ng
+        tedge-container-plugin-ng \
+    # Support updating from older images which still use the deprecated self type
+    && ln -s /usr/bin/tedge-container /etc/tedge/sm-plugins/self
 
 # Set permissions of all files under /etc/tedge
 # TODO: Can thin-edge.io set permissions during installation?

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,12 +2,14 @@
 
 ### Self update
 
+Self updates can be done by using `container` type.
+
 1. Create a repository item
 
     ```sh
     c8y software create \
         --name tedge \
-        --softwareType self
+        --softwareType container
     ```
 
 2. Add a new version
@@ -40,7 +42,7 @@
         --device "subdevice01" \
         --action install \
         --software tedge \
-        --data softwareType=self \
+        --data softwareType=container \
         --url " " \
         --version "ghcr.io/thin-edge/tedge-container-bundle:latest"
     ```

--- a/tests/main/self-update-compat.robot
+++ b/tests/main/self-update-compat.robot
@@ -31,6 +31,6 @@ Upgrade From Base Image
     ${operation}=    Cumulocity.Install Software
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}
 
-    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=180
     Device Should Have Installed Software
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}

--- a/tests/main/self-update-compat.robot
+++ b/tests/main/self-update-compat.robot
@@ -33,4 +33,4 @@ Upgrade From Base Image
 
     Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -26,7 +26,7 @@ Trigger self update via local command
 
 Self update should only update if there is a new image
     ${operation}=    Cumulocity.Install Software
-    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}
     Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
     # robocop: disable=todo-in-comment
     # TODO: Robotframework does not provide an easy way to provide the datetime with timezone (which is required by c8y-api)
@@ -35,23 +35,42 @@ Self update should only update if there is a new image
 Self update using software update operation
     # pre-condition
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}    timeout=10
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}
+    ...    timeout=10
 
     ${operation}=    Cumulocity.Install Software
-    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "self"}
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "container"}
 
     Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "self"}
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "container"}
 
 Rollback when trying to install a non-tedge based image
     # pre-condition
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}    timeout=10
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}
+    ...    timeout=10
 
     ${operation}=    Cumulocity.Install Software
-    ...    {"name": "tedge", "version": "docker.io/library/alpine:latest", "softwareType": "self"}
+    ...    {"name": "tedge", "version": "docker.io/library/alpine:latest", "softwareType": "container"}
 
     Cumulocity.Operation Should Be FAILED    ${operation}    timeout=120
     Device Should Have Installed Software
-    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "self"}
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}
+
+Self update using software update operation using Container type
+    # pre-condition
+    Device Should Have Installed Software
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}
+    ...    timeout=10
+    Device Should Not Have Installed Software
+    ...    {"name": "app20", "version": "docker.io/library/nginx:1-alpine", "softwareType": "container"}    timeout=10
+
+    ${operation}=    Cumulocity.Install Software
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "container"}
+    ...    {"name": "app20", "version": "docker.io/library/nginx:1-alpine", "softwareType": "container"}
+
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
+    Device Should Have Installed Software
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "container"}
+    ...    {"name": "app20", "version": "docker.io/library/nginx:1-alpine", "softwareType": "container"}

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -11,7 +11,7 @@ Test Tags           self-update
 *** Test Cases ***
 Trigger self update via local command
     [Tags]    self-update    test:retry(2)
-    # WORKAROUND: Test fails sporadically due to the tedge-agent occassionaly processing the command twice
+    # WORKAROUND: Test fails sporadically due to the tedge-agent occasionally processing the command twice
     # Though it may have been fixed since 1.3.1
     ${cmd_id}=    DateTime.Get Current Date    time_zone=UTC    result_format=epoch
     ${topic}=    Set Variable    te/device/main///cmd/self_update/local-${cmd_id}

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -70,7 +70,7 @@ Self update using software update operation using Container type
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "container"}
     ...    {"name": "app20", "version": "docker.io/library/nginx:1-alpine", "softwareType": "container"}
 
-    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=180
     Device Should Have Installed Software
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "container"}
     ...    {"name": "app20", "version": "docker.io/library/nginx:1-alpine", "softwareType": "container"}


### PR DESCRIPTION
Container self updating is now supported by the `container` sm-plugin type instead of `self`. The `self` type is no longer part of the container image.