### PR TITLE
feat: use predictable container names for remote access and self updates

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -18,33 +18,29 @@ Self updates can be done by using `container` type.
     c8y software versions create \
         --software tedge \
         --url " " \
-        --version "ghcr.io/thin-edge/tedge-container-bundle:20240929.1503"
+        --version "ghcr.io/thin-edge/tedge-container-bundle:20241201.0920"
     ```
 
-    ```sh
-    c8y software versions create \
-        --software tedge \
-        --url " " \
-        --version "ghcr.io/thin-edge/tedge-container-bundle:latest"
-    ```
-
-3. Create an operation to install software
-
-    ```sh
-    c8y software versions install \
-        --action install \
-        --software tedge \
-        --version "ghcr.io/thin-edge/tedge-container-bundle:latest"
-    ```
+3. Create an operation to install software (go-c8y-cli >= v2.45.0)
 
     ```sh
     c8y software versions install \
         --device "subdevice01" \
         --action install \
         --software tedge \
-        --data softwareType=container \
+        --version "ghcr.io/thin-edge/tedge-container-bundle:20241201.0920"
+    ```
+
+    Or if you haven't created a `tedge` software repository item, then you can install software without it, by specifying all of the required fields (including a empty space for the `--url` flag.)
+
+    ```sh
+    c8y software versions install \
+        --device "subdevice01" \
+        --action install \
+        --software tedge \
+        --softwareType container \
         --url " " \
-        --version "ghcr.io/thin-edge/tedge-container-bundle:latest"
+        --version "ghcr.io/thin-edge/tedge-container-bundle:20241201.0920"
     ```
 
 

--- a/files/tedge/launch-remote-access.sh
+++ b/files/tedge/launch-remote-access.sh
@@ -19,5 +19,5 @@ if [ "$REMOTE_ACCESS_DISABLE_CONTAINER_SPAWN" = 1 ] || ! has_container_api_acces
 fi
 
 echo "Launching session in an independent container"
-$SUDO tedge-container tools run-in-context --rm -- c8y-remote-access-plugin --child "$@"
+$SUDO tedge-container tools run-in-context --name-prefix remoteaccess-connect --rm -- c8y-remote-access-plugin --child "$@"
 exit 0

--- a/files/tedge/self_update.toml
+++ b/files/tedge/self_update.toml
@@ -19,7 +19,7 @@ on_exit.2 = "successful"
 on_exit._ = "failed"
 
 [update]
-script = "sudo -E tedge-container tools container-clone --fork --image ${.payload.image} --container ${.payload.containerName} --stop-after 10s"
+script = "sudo -E tedge-container tools container-clone --fork --image ${.payload.image} --container ${.payload.containerName} --fork-name ${.payload.containerName}-updater --stop-after 10s"
 on_success = "wait-for-container-stop"
 on_error = "failed"
 
@@ -31,6 +31,11 @@ on_exec = "resume-update"
 [resume-update]
 # Wait before verifying to give the container updater to verify the image
 script = "sh -c 'sudo -E tedge-container self list && sleep 60'"
+on_success = "collect-logs"
+on_error = "collect-logs"
+
+[collect-logs]
+script = "sh -c 'sudo -E tedge-container tools container-logs ${.payload.containerName}-updater && sudo -E tedge-container tools container-remove ${.payload.containerName}-updater'"
 on_success = "verify"
 on_error = "verify"
 

--- a/test-images/debian-systemd-podman-cli/Dockerfile
+++ b/test-images/debian-systemd-podman-cli/Dockerfile
@@ -4,6 +4,9 @@ ARG TARGETPLATFORM
 # Allow ssh connection from container network
 RUN sed -i 's|^ListenAddress 127.0.0.1|ListenAddress 0.0.0.0|g' /etc/ssh/sshd_config
 
+# Disable tedge-container-plugin running on the host
+RUN systemctl disable tedge-container-plugin
+
 RUN tedge config unset c8y.proxy.client.host \
     && tedge config unset mqtt.client.host \
     && tedge config unset http.client.host

--- a/tests/main/container.robot
+++ b/tests/main/container.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Resource            ../resources/common.resource
+
+Test Setup          Setup Device
+Test Teardown       Stop Device
+
+
+*** Test Cases ***
+Ignore Containers Marked With A Specific Label
+    ${operation}=    Cumulocity.Execute Shell Command
+    ...    text=sudo -E tedge-container engine docker run -d --label tedge.ignore=1 --network bridge --name manualapp10 docker.io/library/alpine:3.18 sleep infinity
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Sleep    5s
+    Should Have Services    service_type=container    name=manualapp10    max_count=0    min_count=0


### PR DESCRIPTION
Use predictable names for:
* c8y-remote-access-plugin connections containers
* self update orchestrator. This allows the inclusion of the updater logs within the workflow.