### PR TITLE
fix(self-update): remove updater container after collecting logs

### DIFF
--- a/files/tedge/self_update.toml
+++ b/files/tedge/self_update.toml
@@ -35,7 +35,7 @@ on_success = "collect-logs"
 on_error = "collect-logs"
 
 [collect-logs]
-script = "sh -c 'sudo -E tedge-container tools container-logs ${.payload.containerName}-updater && sudo -E tedge-container tools container-remove ${.payload.containerName}-updater'"
+script = "sh -c 'sudo -E tedge-container tools container-logs ${.payload.containerName}-updater; sudo -E tedge-container tools container-remove ${.payload.containerName}-updater'"
 on_success = "verify"
 on_error = "verify"
 

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -45,6 +45,9 @@ Self update using software update operation
     Device Should Have Installed Software
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "container"}
 
+    # updater container should be removed (logs are already collected as part of the workflow)
+    Cumulocity.Should Have Services    service_type=container    name=tedge-updater    min_count=0    max_count=0
+
 Rollback when trying to install a non-tedge based image
     # pre-condition
     Device Should Have Installed Software


### PR DESCRIPTION
Remove the self-update container after the self update has completed (and the logs have been collected from it).