### PR TITLE
feat: switch from c8y-command-plugin to tedge-command-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN case ${TARGETPLATFORM} in \
 RUN rm -f /etc/tedge/system.toml
 RUN wget -O - https://thin-edge.io/install-services.sh | sh -s -- s6_overlay \
     && apk add --no-cache \
-        c8y-command-plugin \
+        tedge-command-plugin \
         tedge-apk-plugin \
         # Enable easier management of containers using docker compose
         # without requiring the cli to be installed on the host (as read-only filesystems)


### PR DESCRIPTION
Use new generic tedge-command-plugin which uses a new thin-edge.io 1.4.0 feature which allows custom operation handlers to use thin-edge.io workflows.