### PR TITLE
ci: remove latest tag from test container image

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,7 +37,6 @@ build OUTPUT_TYPE=DEFAULT_OUTPUT_TYPE VERSION='latest': build-setup
         --build-arg "TEDGE_IMAGE={{TEDGE_IMAGE}}" \
         --build-arg "TEDGE_TAG={{TEDGE_TAG}}" \
         -t "{{REGISTRY}}/{{REPO_OWNER}}/{{IMAGE}}:{{VERSION}}" \
-        -t "{{REGISTRY}}/{{REPO_OWNER}}/{{IMAGE}}:latest" \
         -f Dockerfile \
         --output=type="{{OUTPUT_TYPE}}",oci-mediatypes=false \
         --provenance=false \


### PR DESCRIPTION
Remove the latest tag from the test container images to avoid the image's other tags being removed during image pruning.