### PR TITLE
fix: add tedge-write to tedge's sudoers rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ RUN wget -O - https://thin-edge.io/install-services.sh | sh -s -- s6_overlay \
 # Set permissions of all files under /etc/tedge
 # TODO: Can thin-edge.io set permissions during installation?
 RUN chown -R tedge:tedge /etc/tedge \
-    && echo "tedge  ALL = (ALL) NOPASSWD:SETENV: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /usr/bin/tedgectl, /bin/kill, /usr/bin/tedge-container, /usr/bin/docker, /usr/bin/podman, /usr/bin/podman-remote, /usr/bin/podman-compose" >/etc/sudoers.d/tedge
+    && echo "tedge  ALL = (ALL) NOPASSWD:SETENV: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /usr/bin/tedgectl, /bin/kill, /usr/bin/tedge-container, /usr/bin/docker, /usr/bin/podman, /usr/bin/podman-remote, /usr/bin/podman-compose" >/etc/sudoers.d/tedge \
+    && echo "tedge  ALL = (ALL) NOPASSWD:SETENV: /usr/bin/tedge-write /etc/*" >> /etc/sudoers.d/tedge
 # Custom init. scripts - e.g. write env variables data to files
 COPY cont-init.d/*  /etc/cont-init.d/
 

--- a/tests/main/files/tedge-configuration-plugin.v2.toml
+++ b/tests/main/files/tedge-configuration-plugin.v2.toml
@@ -1,0 +1,5 @@
+files = [
+    { path = '/etc/tedge/tedge.toml', type = 'tedge.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
+    { path = '/etc/tedge/system.toml', type = 'system.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
+    { path = '/etc/tedge/plugins/tedge-log-plugin.toml', type = 'tedge-log-plugin', user = 'tedge', group = 'tedge', mode = 0o644 },
+]

--- a/tests/main/operations.robot
+++ b/tests/main/operations.robot
@@ -29,6 +29,11 @@ Get Configuration File
     tedge.toml
     system.toml
 
+Set Configuration File
+    ${binary_url}=    Create Inventory Binary    tedge-configuration-plugin.toml    toml    file=${CURDIR}/files/tedge-configuration-plugin.v2.toml
+    ${operation}=    Set Configuration    tedge-configuration-plugin    url=${binary_url}
+    Operation Should Be SUCCESSFUL    ${operation}
+
 Execute Shell Command
     ${operation}=    Cumulocity.Execute Shell Command    ls -l /etc/tedge
     Cumulocity.Operation Should Be SUCCESSFUL    ${operation}


### PR DESCRIPTION
Add the `tedge-write` utility to the sudoers.d/tedge definition to allow the tedge-configuration-plugin to set the file ownership and permissions when writing a file to the container.

A system test was also added to cover this use-case in the future.