### PR TITLE
enhance self_update with option to restart container

### DIFF
--- a/files/tedge/self_update.toml
+++ b/files/tedge/self_update.toml
@@ -41,10 +41,13 @@ on_success = "restart"
 on_error = "collect-logs"
 
 [restart]
-# the cmd 'tedge-container tools container-restart' needs to be implemented in https://github.com/thin-edge/tedge-container-plugin/blob/main/cli/tools/cmd.go, as only container_clone, container_remove, ... exists
-script = "sh -c 'sudo -E tedge-container tools container-restart ${.payload.containerName}'"
+operation = "restart"
+on_exec = "await-restart"
+
+[await-restart]
+action = "await-operation-completion"
 on_success = "collect-logs"
-on_error = "collect-logs"
+on_error = "failed"
 
 [collect-logs]
 script = "sh -c 'sudo -E tedge-container tools container-logs ${.payload.containerName}-updater; sudo -E tedge-container tools container-remove ${.payload.containerName}-updater'"

--- a/files/tedge/self_update.toml
+++ b/files/tedge/self_update.toml
@@ -35,10 +35,10 @@ on_success = "needs_restart"
 on_error = "needs_restart"
 
 [needs_restart]
-# if env. variable TEDGE_RESTART_ON_SELF_UPDATE is set and has value TRUE the updated container is restarted
-script = "sh -c 'if [ ! -z "${TEDGE_RESTART_ON_SELF_UPDATE}" ] && [ "${TEDGE_RESTART_ON_SELF_UPDATE}" = "TRUE" ]; then exit 0; else exit 1; fi'"
-on_success = "restart"
-on_error = "collect-logs"
+script = """sh -c '[ "${TEDGE_RESTART_ON_SELF_UPDATE:-}" = 1 ] && exit 2'"""
+on_exit.0 = "collect-logs"
+on_exit.2 = "restart"
+on_exit._ = "failed"
 
 [restart]
 operation = "restart"

--- a/files/tedge/self_update.toml
+++ b/files/tedge/self_update.toml
@@ -31,6 +31,18 @@ on_exec = "resume-update"
 [resume-update]
 # Wait before verifying to give the container updater to verify the image
 script = "sh -c 'sudo -E tedge-container self list && sleep 60'"
+on_success = "needs_restart"
+on_error = "needs_restart"
+
+[needs_restart]
+# if env. variable TEDGE_RESTART_ON_SELF_UPDATE is set and has value TRUE the updated container is restarted
+script = "sh -c 'if [ ! -z "${TEDGE_RESTART_ON_SELF_UPDATE}" ] && [ "${TEDGE_RESTART_ON_SELF_UPDATE}" = "TRUE" ]; then exit 0; else exit 1; fi'"
+on_success = "restart"
+on_error = "collect-logs"
+
+[restart]
+# the cmd 'tedge-container tools container-restart' needs to be implemented in https://github.com/thin-edge/tedge-container-plugin/blob/main/cli/tools/cmd.go, as only container_clone, container_remove, ... exists
+script = "sh -c 'sudo -E tedge-container tools container-restart ${.payload.containerName}'"
 on_success = "collect-logs"
 on_error = "collect-logs"
 


### PR DESCRIPTION
This PR contains an additional step in the workflow self_update to restart the updated tedge container.
This optional step can be configured through setting the env. varaible TEDGE_RESTART_ON_SELF_UPDATE.

This PR requires additional changes in the https://github.com/thin-edge/tedge-container-plugin/blob/main/cli/tools/cmd.go to support a container-restart command.