### PR TITLE
feat: use fixed user id and group id to easy sharing of files from host to container

### DIFF
--- a/cont-init.d/50_configure.sh
+++ b/cont-init.d/50_configure.sh
@@ -69,7 +69,7 @@ load_from_file() {
     fi
 
     # Don't actually do anything, but confirm the presence of device certificates
-    echo "Loading device certifcates from file (no-op)"
+    echo "Loading device certificates from file (no-op)"
 }
 
 create_tedge_config_symlink() {

--- a/cont-init.d/50_configure.sh
+++ b/cont-init.d/50_configure.sh
@@ -110,6 +110,11 @@ create_tedge_config_symlink() {
 ############
 # Main
 ############
+# fix permissions in case if the tedge user has had its uid/gid changed across a container update
+if command -V sudo >/dev/null 2>&1; then
+    export DATA_DIR
+    sudo -E DATA_DIR="$DATA_DIR" /usr/bin/fix-permissions.sh
+fi
 
 if [ "$PERSIST_TEDGE_TOML" = 1 ]; then
     create_tedge_config_symlink

--- a/files/tedge/fix-permissions.sh
+++ b/files/tedge/fix-permissions.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+# Enforce permissions in cases where the base image has changed the UID and GID across container updates
+if [ "$(id -u)" != 0 ]; then
+    echo "Skipping fixing of ownership as the script was not called as root. script=$0" >&2
+    exit 0
+fi
+
+echo "Changing ownership of thin-edge.io folders" >&2
+[ -d "$DATA_DIR" ] && chown -R tedge:tedge "$DATA_DIR"
+[ -d /etc/tedge ] && chown -R tedge:tedge /etc/tedge
+[ -d /var/tedge ] && chown -R tedge:tedge /var/tedge


### PR DESCRIPTION
Use a fixed user id and group id (matching the defaults used in Yocto and Rugix), so that it is easier to share files and sockets from the host to the container (as the container uses a non-root user by default).