### PR TITLE
chore: update to tedge 1.5.0

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ set export
 
 IMAGE := env_var_or_default("IMAGE", "tedge-container-bundle")
 TEDGE_IMAGE := env_var_or_default("TEDGE_IMAGE", "tedge")
-TEDGE_TAG := env_var_or_default("TEDGE_TAG", "1.4.2")
+TEDGE_TAG := env_var_or_default("TEDGE_TAG", "1.5.0")
 
 REGISTRY := "ghcr.io"
 REPO_OWNER := "thin-edge"


### PR DESCRIPTION
Update default version to thin-edge.io 1.5.0