### PR TITLE
chore: update to thin-edge.io 1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TEDGE_TAG=1.4.2
+ARG TEDGE_TAG=1.5.1
 # thin-edge.io base image name: tedge, tedge-main
 ARG TEDGE_IMAGE=tedge
 FROM ghcr.io/thin-edge/${TEDGE_IMAGE}:${TEDGE_TAG}

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ set export
 
 IMAGE := env_var_or_default("IMAGE", "tedge-container-bundle")
 TEDGE_IMAGE := env_var_or_default("TEDGE_IMAGE", "tedge")
-TEDGE_TAG := env_var_or_default("TEDGE_TAG", "1.5.0")
+TEDGE_TAG := env_var_or_default("TEDGE_TAG", "1.5.1")
 
 REGISTRY := "ghcr.io"
 REPO_OWNER := "thin-edge"


### PR DESCRIPTION
Update to thin-edge.io 1.5.1 by default