### PR TITLE
feat: add option to register container using the Cumulocity certificate-authority feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ After the project pre-requisites have been installed, you can start the containe
     just test
     ```
 
+#### Cumulocity Certificate Authority (Preview)
+
+Note: These instructions use the Cumulocity certificate-authority feature and a UI change (pre-filling registration via a URL) which might not be deployed on your tenant.
+
+1. Active your Cumulocity session using go-c8y-cli
+
+    ```sh
+    set-session
+    ```
+
+2. Start the local image (running in the foreground)
+
+    ```sh
+    docker compose up --build
+    ```
+
+3. Click on the registration url to be redirected to the Cumulocity URL in your browser and confirm the registration
+
 ## Project structure
 
 |Directory|Description|

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,21 @@
+services:
+  tedge:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: always
+    environment:
+      - C8Y_DOMAIN=${C8Y_DOMAIN:-}
+      - DEVICE_ID=${DEVICE_ID:-}
+      - ENABLE_C8Y_CA=${ENABLE_C8Y_CA:-1}
+    tmpfs:
+      - /tmp
+    volumes:
+      - device-certs:/etc/tedge/device-certs
+      - tedge:/data/tedge
+      # Enable docker from docker
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+
+volumes:
+  device-certs:
+  tedge:


### PR DESCRIPTION
Add option to register container using the Cumulocity certificate-authority feature, but the feature is disabled by default at the moment.