### PR TITLE
feat: add doc notes to the Cumulocity certificate-authority feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN wget -O - https://thin-edge.io/install-services.sh | sh -s -- s6_overlay \
         # might not have access to it
         # Note: Volumes should be configured to persist the docker compose files
         docker-cli-compose \
-        tedge-container-plugin-ng \
+        "tedge-container-plugin-ng<2.3.0" \
     # Support updating from older images which still use the deprecated self type
     && ln -s /usr/bin/tedge-container /etc/tedge/sm-plugins/self
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ Note: These instructions use the Cumulocity certificate-authority feature and a 
 
 3. Click on the registration url to be redirected to the Cumulocity URL in your browser and confirm the registration
 
+
+**Notes**
+
+You can change the default device enrollment by setting the following environment variables on the container. 
+
+```sh
+C8Y_DOMAIN=example-demo.eu-latest.cumulocity.com
+DEVICE_ID=tedge_mydevice001
+DEVICE_ONE_TIME_PASSWORD=<max_32_chars>
+```
+
 ## Project structure
 
 |Directory|Description|

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
     environment:
       - C8Y_DOMAIN=${C8Y_DOMAIN:-}
       - DEVICE_ID=${DEVICE_ID:-}
+      - DEVICE_ONE_TIME_PASSWORD=${DEVICE_ONE_TIME_PASSWORD:-}
       - CA=${CA:-c8y}
     tmpfs:
       - /tmp


### PR DESCRIPTION
Add some notes to the readme to guide new users how to use the new Cumulocity certificate-authority feature and how to set the device id and one-time password.