### PR TITLE
feat: add support Cumulocity basic auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,8 @@ RUN wget -O - https://thin-edge.io/install-services.sh | sh -s -- s6_overlay \
 # TODO: Can thin-edge.io set permissions during installation?
 RUN usermod -u "$USERID" tedge \
     && groupmod -g "$GROUPID" tedge \
+    # create empty folder so basic auth credentials can be mounted to it
+    && mkdir -p /etc/tedge/credentials \
     && chown -R tedge:tedge /etc/tedge \
     && chown -R tedge:tedge /var/tedge \
     && echo "tedge  ALL = (ALL) NOPASSWD:SETENV: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /usr/bin/tedgectl, /bin/kill, /usr/bin/tedge-container, /usr/bin/docker, /usr/bin/podman, /usr/bin/podman-remote, /usr/bin/podman-compose" >/etc/sudoers.d/tedge \
@@ -90,6 +92,8 @@ COPY files/tedge/log_upload.toml /etc/tedge/operations/
 COPY files/tedge/log_upload_container.toml /etc/tedge/operations/
 # Script to fix the permissions / ownership which is called on container startup
 COPY files/tedge/fix-permissions.sh /usr/bin/
+# Helper script to set the Cumulocity Basic Auth more easily
+COPY files/tedge/set-c8y-basic-auth.sh /usr/bin/
 
 
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The following are required in order to deploy the container
 
 [Option 2b (Cumulocity Certificate Authority Preview): Container network (Recommended)](./docs/CONTAINER_OPTION2_with_ca.md)
 
+[Option 2c (Basic Auth): Container network (Recommended)](./docs/CONTAINER_OPTION2_with_basic_auth.md)
+
 
 ### Settings
 

--- a/docs/CONTAINER_OPTION2_with_basic_auth.md
+++ b/docs/CONTAINER_OPTION2_with_basic_auth.md
@@ -1,0 +1,185 @@
+## Option 2: Container network and using Cumulocity Basic Auth
+
+**When to use it?**
+
+* Familiar with containers
+* Basic understanding of container networking
+* You can't use certificate based auth for reason
+
+## Getting Started
+
+
+### Option 1: Using docker run
+
+1. Pull the latest image
+
+    ```sh
+    docker pull ghcr.io/thin-edge/tedge-container-bundle
+    ```
+
+1. Create Cumulocity basic auth credentials for your new device. For convenience, you can use go-c8y-cli to do this
+
+    ```sh
+    c8y deviceregistration register-basic --id tedge_abcdef
+    ```
+
+1. Set some environment variable based on the Cumulocity instance you wish to connect to, and the device id
+
+    ```sh
+    export TEDGE_C8Y_URL="example-demo.eu-latest.cumulocity.com"
+    export DEVICE_ID="tedge_abcdef"
+    export C8Y_DEVICE_USER="t12345/device_${DEVICE_ID}"
+    export C8Y_DEVICE_PASSWORD="<<code_max_32_chars>>"
+    ```
+
+    **Note** The username must be in the form of `{tenant}/device_{name}`.
+
+1. Create a docker volume which will be used to store the device credentials, and a volume for the tedge and mosquitto data
+
+    ```sh
+    docker network create tedge
+    docker volume create device-creds
+    docker volume create tedge
+    ```
+
+3. Create a new device credentials
+
+    ```sh
+    docker run --rm -it \
+        -v "device-creds:/etc/tedge/credentials" \
+        -e "TEDGE_C8Y_CREDENTIALS_PATH=/etc/tedge/credentials/credentials.toml" \
+        ghcr.io/thin-edge/tedge-container-bundle:latest \
+        /usr/bin/set-c8y-basic-auth.sh "$C8Y_DEVICE_USER" "$C8Y_DEVICE_PASSWORD"
+    ```
+
+    Alternatively, you can set the Cumulocity device username and password using environment variables, however be aware that they could then be read by anyone with access to the container engine.
+
+    ```sh
+    -e "C8Y_DEVICE_USER=$C8Y_DEVICE_USER" \
+    -e "C8Y_DEVICE_PASSWORD=$C8Y_DEVICE_PASSWORD" \
+    ```
+
+1. Start the container
+
+    ```sh
+    docker run -d \
+        --name tedge \
+        --restart always \
+        --add-host host.docker.internal:host-gateway \
+        --network tedge \
+        -p "127.0.0.1:1883:1883" \
+        -p "127.0.0.1:8000:8000" \
+        -p "127.0.0.1:8001:8001" \
+        -v device-creds:/etc/tedge/credentials \
+        -v tedge:/data/tedge \
+        -v /var/run/docker.sock:/var/run/docker.sock:rw \
+        -e TEDGE_C8Y_OPERATIONS_AUTO_LOG_UPLOAD=always \
+        -e "DEVICE_ID=${DEVICE_ID}" \
+        -e "TEDGE_C8Y_URL=${TEDGE_C8Y_URL}" \
+        -e "TEDGE_C8Y_AUTH_METHOD=auto" \
+        -e "TEDGE_C8Y_CREDENTIALS_PATH=/etc/tedge/credentials/credentials.toml" \
+        ghcr.io/thin-edge/tedge-container-bundle:latest
+    ```
+
+    With this option, you can change the host port mapping in case it conflicts with any other services running on the host, e.g. other services which are already using the ports that thin-edge.io wants to use.
+
+    ```sh
+    docker run -d \
+        --name tedge \
+        --restart always \
+        --add-host host.docker.internal:host-gateway \
+        --network tedge \
+        -p "127.0.0.1:1884:1883" \
+        -p "127.0.0.1:9000:8000" \
+        -p "127.0.0.1:9001:8001" \
+        -v device-creds:/etc/tedge/credentials \
+        -v tedge:/data/tedge \
+        -v /var/run/docker.sock:/var/run/docker.sock:rw \
+        -e TEDGE_C8Y_OPERATIONS_AUTO_LOG_UPLOAD=always \
+        -e "DEVICE_ID=${DEVICE_ID}" \
+        -e "TEDGE_C8Y_URL=${TEDGE_C8Y_URL}" \
+        -e "TEDGE_C8Y_AUTH_METHOD=auto" \
+        -e "TEDGE_C8Y_CREDENTIALS_PATH=/etc/tedge/credentials/credentials.toml" \
+        ghcr.io/thin-edge/tedge-container-bundle:latest
+    ```
+
+
+### Option 2: Using docker compose
+
+Note: This docker compose example uses environment variable to set the basic auth. Ideally you would not set the credentials this ways as it makes them readable to anyone whom has access to the container engine.
+
+1. In a shell, create a new folder and change directory into it. The name of the folder will be your docker compose project name
+
+1. Create a `.env` file with the following contents
+
+    ```sh
+    TEDGE_C8Y_URL="example-demo.eu-latest.cumulocity.com"
+    export DEVICE_ID="tedge_abcdef"
+    export C8Y_DEVICE_USER="t12345/device_${DEVICE_ID}"
+    export C8Y_DEVICE_PASSWORD="<<code_max_32_chars>>"
+
+    # any other custom thin-edge.io configuration that you want
+    TEDGE_C8Y_OPERATIONS_AUTO_LOG_UPLOAD=always
+    ```
+
+1. Create a `docker-compose.yaml` file with the following contents
+
+    ```yaml
+    services:
+      tedge:
+        image: ghcr.io/thin-edge/tedge-container-bundle
+        restart: always
+        environment:
+          - TEDGE_C8Y_AUTH_METHOD=auto
+          - TEDGE_C8Y_CREDENTIALS_PATH=/etc/tedge/credentials/credentials.toml
+        env_file:
+          - .env
+        ports:
+         - 127.0.0.1:1883:1883
+         - 127.0.0.1:8000:8000
+         - 127.0.0.1:8001:8001
+        # When using docker, add access to the host
+        # if you want to be able to ssh into the host from the container
+        extra_hosts:
+          - host.docker.internal:host-gateway
+        tmpfs:
+          - /tmp
+        volumes:
+          - device-creds:/etc/tedge/credentials
+          - tedge:/data/tedge
+          # Enable docker from docker
+          - /var/run/docker.sock:/var/run/docker.sock:rw
+
+    volumes:
+      device-creds:
+      tedge:
+    ```
+
+1. Start the container using docker compose
+
+    ```sh
+    docker compose up -d
+    ```
+
+## Using the tedge-container-bundle
+
+### Subscribing to the MQTT broker
+
+Assuming the container network is called `tedge`, then you can subscribe to the MQTT broker using the following command:
+
+```sh
+docker run --rm -it \
+    --network tedge \
+    -e TEDGE_MQTT_CLIENT_HOST=tedge \
+    ghcr.io/thin-edge/tedge-container-bundle \
+    tedge mqtt sub '#'
+```
+
+Or you can access the MQTT broker directly from the host using the port mappings:
+
+```sh
+mosquitto_sub -h 127.0.0.1 -p 1883 -t '#'
+
+# or if you used another port
+mosquitto_sub -h 127.0.0.1 -p 1884 -t '#'
+```

--- a/files/tedge/set-c8y-basic-auth.sh
+++ b/files/tedge/set-c8y-basic-auth.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+if [ $# -lt 2 ]; then
+    echo "ERROR: Expected 2 arguments." >&2
+    echo "USAGE: $0 <C8Y_DEVICE_USER> <C8Y_DEVICE_PASSWORD>" >&2
+    exit 1
+fi
+CREDENTIALS_PATH=$(tedge config get c8y.credentials_path)
+printf '[c8y]\nusername = "%s"\npassword = "%s"\n' "$1" "$2" > "$CREDENTIALS_PATH"
+chmod 600 "$CREDENTIALS_PATH"

--- a/tests/main/c8y-basic-auth.robot
+++ b/tests/main/c8y-basic-auth.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Resource            ../resources/common.resource
+Library             DateTime
+
+Test Teardown       Stop Device
+
+
+*** Test Cases ***
+Supports Cumulocity Basic Auth Credentials
+    Setup Device With Basic Auth Credentials
+
+    ${operation}=    Cumulocity.Get Configuration    typename=tedge-configuration-plugin
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -83,6 +83,6 @@ Self update using software update operation using Container type
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "container"}
     ...    {"name": "app20", "version": "docker.io/library/nginx:1-alpine", "softwareType": "container"}
 
-    ${operation}=    Execute Shell Command    tedge config get c8y.availability.interval
+    ${operation}=    Execute Shell Command    tedge config get c8y.availability.interval 2>/dev/null
     ${operation}=    Operation Should Be SUCCESSFUL    ${operation}
     Should Be Equal As Strings    ${operation["c8y_Command"]["result"]}    61m${\n}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 robotframework~=7.0.0
 robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.42.4
-robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.17.1
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.18.0
 robotframework-tidy~=4.14.0
 robotframework-robocop~=5.5.0
 robotframework-retryfailed~=0.2.0

--- a/tests/resources/common.resource
+++ b/tests/resources/common.resource
@@ -42,6 +42,20 @@ Setup Device With Self Signed Certificate
     Set Suite Variable    ${DEVICE_ID}
     Cumulocity.External Identity Should Exist    ${DEVICE_ID}
 
+Setup Device With Basic Auth Credentials
+    [Arguments]    ${image}=
+    ${DEVICE_ID}=    DeviceLibrary.Setup    skip_bootstrap=${True}
+
+    ${creds}=    Cumulocity.Bulk Register Device With Basic Auth    external_id=${DEVICE_ID}
+
+    Transfer To Device    ${CURDIR}/../../test-images/common/container-bundle.sh    /usr/bin/
+    Transfer To Device    ${CURDIR}/../*.tar.gz    /build/
+    Execute Command
+    ...    container-bundle.sh start --device-id '${DEVICE_ID}' --c8y-url '${C8Y_CONFIG.host}' --auth-type basic --c8y-device-user '${creds.username}' --c8y-device-password '${creds.password}' --image "${image}" --debug 2>&1
+
+    Set Suite Variable    ${DEVICE_ID}
+    Cumulocity.External Identity Should Exist    ${DEVICE_ID}
+
 Stop Device
     DeviceLibrary.Execute Command    container-bundle.sh stop --device-id '${DEVICE_ID}' --debug
     Cumulocity.Delete Managed Object And Device User    ${DEVICE_ID}


### PR DESCRIPTION
Add support for connecting the tedge-container-bundle to Cumulocity using basic auth instead of certificates.

Certificates are still the preferred method, however it allows users more options to connect to Cumulocity.