### PR TITLE
fix: persist tedge-container-plugin data by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,10 @@ ENV TEDGE_C8Y_PROXY_CLIENT_HOST=127.0.0.1
 ENV TEDGE_AGENT_STATE_PATH="$DATA_DIR/agent"
 ENV TEDGE_LOGS_PATH="$DATA_DIR/logs"
 
+# ensure tedge-container-plugin data is stored in a persistent directory
+ENV CONTAINER_DATA_DIR="$DATA_DIR/tedge-container-plugin/data"
+ENV CONTAINER_REGISTRY_CREDENTIALS_PATH="$DATA_DIR/tedge-container-plugin/credentials.toml"
+
 # Persist tedge.toml under /data/tedge/tedge.toml by using
 # a symlink from /etc/tedge/tedge.toml to /data/tedge/tedge.toml
 # This allows the tedge.toml to be maintained across updates

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -63,10 +63,16 @@ Rollback when trying to install a non-tedge based image
 
 Self update using software update operation using Container type
     # Change a tedge.toml value to see if it is persisted
-    Execute Command    cmd=podman exec tedge test -L /etc/tedge/tedge.toml || docker exec tedge test -L /etc/tedge/tedge.toml    timeout=30
+    Execute Command
+    ...    cmd=podman exec tedge test -L /etc/tedge/tedge.toml || docker exec tedge test -L /etc/tedge/tedge.toml
+    ...    timeout=30
     ${operation}=    Execute Shell Command    tedge config set c8y.availability.interval 61m
     Operation Should Be SUCCESSFUL    ${operation}
-    
+
+    # Add some data in the container data dir
+    ${operation}=    Execute Shell Command    mkdir -p "$CONTAINER_DATA_DIR" && touch "$CONTAINER_DATA_DIR/foo"
+    Operation Should Be SUCCESSFUL    ${operation}
+
     # pre-condition
     Device Should Have Installed Software
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}
@@ -86,3 +92,7 @@ Self update using software update operation using Container type
     ${operation}=    Execute Shell Command    tedge config get c8y.availability.interval 2>/dev/null
     ${operation}=    Operation Should Be SUCCESSFUL    ${operation}
     Should Be Equal As Strings    ${operation["c8y_Command"]["result"]}    61m${\n}
+
+    # check if the file still exists
+    ${operation}=    Execute Shell Command    test -f "$CONTAINER_DATA_DIR/foo"
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}


### PR DESCRIPTION
Persist the tedge-container-plugin data dir and credentials directory by default by changing the default paths under the container's DATA_DIR.

This ensure that working directory data like docker-compose files are persisted across self updates.