### PR TITLE
fix(test): use fixed podman:v5.7 version and fix test image startup issue

### DIFF
--- a/test-images/podman-v5/Dockerfile
+++ b/test-images/podman-v5/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/containers/podman:v5
+FROM quay.io/containers/podman:v5.7
 RUN systemctl enable podman.socket \
     && echo "enable podman.socket" > /usr/lib/systemd/system-preset/95-podman.preset \
     # create systemd-tmpfiles config to create a symlink for docker to the podman socket

--- a/test-images/podman-v5/Dockerfile
+++ b/test-images/podman-v5/Dockerfile
@@ -5,5 +5,7 @@ RUN systemctl enable podman.socket \
     # which allows using docker and docker compose without having to set the DOCKER_HOST variable
     # Source: podman-docker debian package
     && echo 'L+  %t/docker.sock   -    -    -     -   %t/podman/podman.sock' | tee /usr/lib/tmpfiles.d/podman-docker-socket.conf \
-    && systemd-tmpfiles --create podman-docker-socket.conf >/dev/null || true
+    && systemd-tmpfiles --create podman-docker-socket.conf >/dev/null || true \
+    # disable first boot otherwise the Fedora 43 hangs on startup which prevents other services from starting
+    && rm -f /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service
 ENTRYPOINT [ "/lib/systemd/systemd" ]


### PR DESCRIPTION
Fix an issue with the podman >= 5.6 container images, where the systemd-firstboot service would hang causing other services to fail to start.

To keep the system test images stage, a fixed version v5.7 is now used in the podman v5 line to avoid the systems tests breaking unexpectedly over time which blocks new thin-edge.io releases. 