### PR TITLE
feat: add Cumulocity CA certificate renewer service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,10 @@ COPY files/tedge/fix-permissions.sh /usr/bin/
 # Helper script to set the Cumulocity Basic Auth more easily
 COPY files/tedge/set-c8y-basic-auth.sh /usr/bin/
 
+# certificate renewal service
+COPY files/tedge/cert-renewer/service /etc/s6-overlay/s6-rc.d/cert-renewer
+RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/cert-renewer
+COPY files/tedge/cert-renewer/renew.sh /usr/bin/
 
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=30000
@@ -140,6 +144,10 @@ ENV TEDGE_LOGS_PATH="$DATA_DIR/logs"
 # ensure tedge-container-plugin data is stored in a persistent directory
 ENV CONTAINER_DATA_DIR="$DATA_DIR/tedge-container-plugin/data"
 ENV CONTAINER_REGISTRY_CREDENTIALS_PATH="$DATA_DIR/tedge-container-plugin/credentials.toml"
+
+# Certificate renewal service settings
+ENV RENEW_INTERVAL_SEC=3600
+ENV CERT_RENEW_PUBLISH_EVENTS=1
 
 # Persist tedge.toml under /data/tedge/tedge.toml by using
 # a symlink from /etc/tedge/tedge.toml to /data/tedge/tedge.toml

--- a/files/tedge/cert-renewer/renew.sh
+++ b/files/tedge/cert-renewer/renew.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+export RENEW_WITH_CA="${RENEW_WITH_CA:-c8y}"
+export CERT_RENEW_PUBLISH_EVENTS="${CERT_RENEW_PUBLISH_EVENTS:-1}"
+MAPPERS=
+
+if [ "$SERVICE_TEDGE_MAPPER_C8Y" = 1 ]; then
+    MAPPERS="c8y"
+fi
+
+if [ -z "$MAPPERS" ]; then
+    echo "No mappers specified, so nothing to renew" >&2
+    exit 0
+fi
+
+try_publish_event() {
+    TYPE="$1"
+    MESSAGE="$2"
+    if [ "$CERT_RENEW_PUBLISH_EVENTS" = 1 ]; then
+        timeout 10 tedge mqtt pub "te/device/main///e/$TYPE" "{\"text\":\"$MESSAGE\"}" ||:
+    fi
+}
+
+renew_cert() {
+    NAME="$1"
+    if tedge cert needs-renewal "$NAME"; then
+        if tedge cert renew "$NAME" --ca "${RENEW_WITH_CA}"; then
+            if ! tedge reconnect "$NAME"; then
+                try_publish_event "certificate_renewal_failed" "Failed to reconnect after renewing certificate for $NAME mapper"
+                return 1
+            fi
+            rm -f "$(tedge config get "$NAME".device.cert_path).new"
+            try_publish_event "certificate_renewal" "Successfully renewed certificate for $NAME mapper"
+            return 0
+        else
+            try_publish_event "certificate_renewal_failed" "Failed to renew certificate for $NAME mapper"
+        fi
+    else
+        echo "Certificate does not need renewing. mapper=$NAME" >&2
+    fi
+}
+
+uses_cumulocity_ca() {
+    NAME="$1"
+    tedge cert show "$NAME" | grep "^Issuer:" | grep -q "CN=t[0-9]*"
+}
+
+for MAPPER in $MAPPERS; do
+    if uses_cumulocity_ca "$MAPPER" >/dev/null 2>&1; then
+        renew_cert "$MAPPER" ||:
+    fi
+done

--- a/files/tedge/cert-renewer/service/run
+++ b/files/tedge/cert-renewer/service/run
@@ -1,0 +1,16 @@
+#!/command/with-contenv sh
+set -eu
+
+# Configuration
+: "${RENEW_INTERVAL_SEC:=3600}"     # 1 hour
+
+log() {
+    printf '%s cert-renewer: %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >&2
+}
+
+log "Certificate renewal service started"
+
+while true; do
+    /usr/bin/renew.sh
+    sleep "$RENEW_INTERVAL_SEC"
+done

--- a/files/tedge/cert-renewer/service/type
+++ b/files/tedge/cert-renewer/service/type
@@ -1,0 +1,1 @@
+longrun


### PR DESCRIPTION
Add a cert-renewer service to handle the automatic renewal of a Cumulocity certificate that is issued by the Cumulocity CA.

By default it will check every hour, but only renew the certificate if the certificate will expire soon as controlled by the tedge setting, `certificate.validity.minimum_duration` (which defaults to 30d).

Events are created when the certificate is renewed, but can be turned off by setting the env variable: `CERT_RENEW_PUBLISH_EVENTS=0`. An example of the events are shown below:

<img width="1041" height="256" alt="image" src="https://github.com/user-attachments/assets/becba93b-ee35-454c-b937-59bc02cdc0e3" />


Resolves https://github.com/thin-edge/tedge-container-bundle/issues/103