### PR TITLE
feat: support cert renewal with Thick Edge and C8Y tenant without txxxx tenant ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,6 +148,7 @@ ENV CONTAINER_REGISTRY_CREDENTIALS_PATH="$DATA_DIR/tedge-container-plugin/creden
 # Certificate renewal service settings
 ENV RENEW_INTERVAL_SEC=3600
 ENV CERT_RENEW_PUBLISH_EVENTS=1
+ENV C8Y_CA=0
 
 # Persist tedge.toml under /data/tedge/tedge.toml by using
 # a symlink from /etc/tedge/tedge.toml to /data/tedge/tedge.toml

--- a/files/tedge/cert-renewer/renew.sh
+++ b/files/tedge/cert-renewer/renew.sh
@@ -43,11 +43,18 @@ renew_cert() {
 
 uses_cumulocity_ca() {
     NAME="$1"
+
+    if [ "${C8Y_CA:-0}" = "1" ]; then
+        return 0
+    fi
+
     tedge cert show "$NAME" | grep "^Issuer:" | grep -q "CN=t[0-9]*"
 }
 
 for MAPPER in $MAPPERS; do
     if uses_cumulocity_ca "$MAPPER" >/dev/null 2>&1; then
         renew_cert "$MAPPER" ||:
+    else
+        echo "Certificate issuer does not match Cumulocity CA, mapper=$MAPPER" >&2
     fi
 done


### PR DESCRIPTION
Additional environment variable C8Y_CA check, in case tenant ID is not in 'txxx' format but C8Y CA is in use. The default value of C8Y_CA is 0. It only makes difference when user change it to 1.  

Also added an echo when certificate won't be renewed.