### PR TITLE
ci: refactor test setup to use /test slash command for fork PRs

### DIFF
--- a/.github/workflows/test-slash-command.yaml
+++ b/.github/workflows/test-slash-command.yaml
@@ -1,0 +1,42 @@
+name: Test (Slash Command)
+
+# Listens for /test comments on pull requests.
+# Because issue_comment always runs in the base-repo context, this workflow
+# has access to repository secrets even for fork PRs.
+#
+# When a maintainer (write/maintain/admin) comments "/test" on a PR:
+#   - peter-evans/slash-command-dispatch validates the permission, adds 👀/🚀
+#     reactions, and fires a repository_dispatch event of type "test-command".
+#   - test.yaml picks up that event and runs the matrix tests against the
+#     PR's head SHA (available in client_payload.pull_request).
+#
+# Requires a repo-scoped PAT stored as the COMMUNITY_ACTIONS_PAT secret so that
+# the action can create repository_dispatch events (GITHUB_TOKEN cannot do this).
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  # Required so slash-command-dispatch can add the 👀/🚀 reactions to the
+  # comment (the reaction uses GITHUB_TOKEN by default; a PR comment is an
+  # issue comment, so this needs issues: write). Without it the reaction POST
+  # is rejected and the commenter gets no feedback that /test was accepted.
+  issues: write
+  pull-requests: write
+
+jobs:
+  slash-command-dispatch:
+    name: Dispatch /test command
+    # Only process comments on pull requests
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v5
+        with:
+          token: ${{ secrets.COMMUNITY_ACTIONS_PAT }}
+          commands: test
+          permission: write
+          issue-type: pull-request

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,35 +1,59 @@
 name: Test
 
 on:
-  workflow_dispatch:
-  # Use a manual approval process before PR's are given access to
-  # the secrets which are required to run the integration tests.
-  # The PR code should be manually approved to see if it can be trusted.
-  # When in doubt, do not approve the test run.
-  # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
-  pull_request_target:
+  # Runs automatically for PRs from branches within this repo (maintainers).
+  # Fork PRs do not have access to secrets; maintainers must trigger those
+  # via a /test comment (see test-slash-command.yaml).
+  pull_request:
     branches: [ main ]
+  # Triggered by test-slash-command.yaml via peter-evans/slash-command-dispatch
+  # when a maintainer comments /test on a fork PR.
+  repository_dispatch:
+    types: [test-command]
+  # Allows manually triggering a test run against a specific ref from the UI.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit SHA or branch to test"
+        required: false
+        default: ""
   merge_group:
 
 permissions:
   contents: read
 
 jobs:
-  approve:
-    name: Approve
-    environment:
-      # For security reasons, all pull requests need to be approved first before granting access to secrets
-      # So the environment should be set to have a reviewer/s inspect it before approving it
-      name: ${{ github.event_name == 'pull_request_target' && 'Test Pull Request' || 'Test Auto'  }}
+  # A repository_dispatch run (triggered by a /test comment) is not linked to
+  # the PR, so nothing shows up in the PR's checks. Post a "pending" commit
+  # status against the fork PR's head SHA so the run is visible on the PR while
+  # it executes. The final result is reported by the tests-pass job below.
+  report-pending:
+    name: Report tests running
+    if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
-      - name: Wait for approval
-        run: echo "Approved"
+      - name: Report pending status to PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/statuses/${{ github.event.client_payload.pull_request.head.sha }}" \
+            -f state=pending \
+            -f context="Tests Pass" \
+            -f description="Tests triggered via /test are running" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   test:
     name: Test ${{ matrix.job.name }} (${{ matrix.build.image }}@${{ matrix.build.tag }})
+    # Skip fork PRs on the pull_request event — they have no secret access.
+    # Those PRs are tested via repository_dispatch triggered by test-slash-command.yaml.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    needs: approve
     permissions:
       # Required to publish system test results to the PR
       issues: write
@@ -58,9 +82,12 @@ jobs:
           - { target: tedge-container-bundle, name: "podman v4", image: "podman-v4" }
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          # repository_dispatch: use the fork PR's head SHA from the slash command payload
+          # workflow_dispatch:   use the manually specified ref (or default branch)
+          # pull_request / merge_group: use the default (current SHA)
+          ref: ${{ github.event.client_payload.pull_request.head.sha || inputs.ref || github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -80,7 +107,7 @@ jobs:
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
           cat .env
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -106,9 +133,54 @@ jobs:
           path: output
 
       - name: Send report to commit
+        if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'repository_dispatch') }}
         uses: joonvena/robotframework-reporter-action@v2.5
-        if: always() && github.event_name == 'pull_request_target'
         with:
           gh_access_token: ${{ secrets.GITHUB_TOKEN }}
           report_path: 'output'
           show_passed_tests: 'true'
+          pull_request_id: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+          sha: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+
+  tests-pass:
+    name: Tests Pass
+    needs: [test]
+    # Run for every trigger EXCEPT fork PRs on the pull_request event: those skip
+    # the test job (no secret access), so this gate would otherwise report a red
+    # "Tests Pass" and permanently block the PR. Leaving it unreported keeps the
+    # required check pending until a maintainer comments /test, at which point the
+    # repository_dispatch run below reports the result onto the PR head commit.
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to report the gate result back to the fork PR's head commit
+      # for /test (repository_dispatch) runs.
+      statuses: write
+    steps:
+      - name: Check all matrix jobs passed
+        id: gate
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more matrix jobs failed: ${{ needs.test.result }}"
+            exit 1
+          fi
+
+      - name: Report result to PR
+        # For /test runs, publish the gate outcome as a "Tests Pass" commit
+        # status on the PR head SHA so it shows on the PR and satisfies the
+        # required branch-protection check (repository_dispatch runs are not
+        # otherwise linked to the PR).
+        if: ${{ always() && github.event_name == 'repository_dispatch' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/statuses/${{ github.event.client_payload.pull_request.head.sha }}" \
+            -f state="${{ steps.gate.outcome == 'success' && 'success' || 'failure' }}" \
+            -f context="Tests Pass" \
+            -f description="Tests triggered via /test" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary

Improves how system tests are run on fork PRs by switching from the `pull_request_target` + manual GitHub Environment approval flow to a `/test` slash-command flow, matching [thin-edge/modbus-plugin](https://github.com/thin-edge/modbus-plugin/tree/main/.github/workflows).

- **In-repo PRs** run the system tests automatically on the plain `pull_request` event (no more manual approval step)
- **Fork PRs** have no secret access and are skipped on `pull_request`; a maintainer (write access or above) triggers the tests by commenting `/test` on the PR. The new `test-slash-command.yaml` workflow validates the commenter's permission via [peter-evans/slash-command-dispatch](https://github.com/peter-evans/slash-command-dispatch) and fires a `repository_dispatch` (`test-command`) event that runs the matrix against the PR's head SHA
- Since `repository_dispatch` runs aren't linked to the PR, the run posts a pending **Tests Pass** commit status on the fork PR's head SHA when it starts, and the final gate result when it finishes
- Adds a stable `Tests Pass` gate job that fails if any matrix job failed — use this single check in branch protection instead of the per-matrix job names
- `workflow_dispatch` now accepts an optional `ref` input for manually testing a specific commit/branch
- The `approve` job, the `Test Pull Request` environment gating, and the `pull_request_target` trigger are removed
- Action version bumps: `actions/checkout` v6→v7, `actions/setup-python` v6→v7

## Required repo configuration

- **`COMMUNITY_ACTIONS_PAT` secret**: a repo-scoped PAT is required for the slash-command dispatch workflow — the default `GITHUB_TOKEN` cannot create `repository_dispatch` events (already used by other thin-edge community repos, e.g. modbus-plugin)
- **Branch protection**: change the required status check to `Tests Pass`
- The `Test Pull Request` environment (manual approval) is no longer used and can be deleted; the `Test Auto` environment is still used by the test job

## Maintainer workflow for fork PRs

1. Review the fork PR code (as before — only comment `/test` on code you trust with the test tenant secrets)
2. Comment `/test` on the PR; the bot reacts with 🚀 and the matrix run starts against the PR head SHA
3. The result appears as the `Tests Pass` commit status on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)