### PR TITLE
feat: support self update from a container image file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ output/
 
 # Test artifacts
 tests/*.tar.gz
+tests/images/

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -44,6 +44,123 @@ Self updates can be done by using `container` type.
     ```
 
 
+### Self update from an image file
+
+If the device has no access to a container registry, the image can be uploaded to Cumulocity
+as a binary and installed from there. The archive is created with `docker save` (or
+`podman save`) and must contain the image under the same reference that is used as the
+software version, otherwise the update is rejected.
+
+1. Pull the image on a machine which does have registry access
+
+    The platform (`PLATFORM`) must match the device, as the archive only holds the platform that was
+    pulled.
+
+    ```sh
+    PLATFORM="linux/arm64"
+    VERSION="20241201.0920"
+    docker pull --platform "$PLATFORM" ghcr.io/thin-edge/tedge-container-bundle:$VERSION
+    ```
+
+2. Create the image archive
+
+    ```sh
+    docker save --platform "$PLATFORM" ghcr.io/thin-edge/tedge-container-bundle:$VERSION \
+    | gzip > tedge-container-bundle.tar.gz
+    ```
+
+3. Add a new version with the archive attached
+
+    ```sh
+    c8y software versions create \
+        --software tedge \
+        --version "ghcr.io/thin-edge/tedge-container-bundle:$VERSION" \
+        --file ./tedge-container-bundle.tar.gz
+    ```
+
+4. Install it
+
+    ```sh
+    c8y software versions install \
+        --device "subdevice01" \
+        --action install \
+        --software tedge \
+        --version "ghcr.io/thin-edge/tedge-container-bundle:$VERSION"
+    ```
+
+The same can be triggered locally by adding a `url` to the `self_update` command:
+
+```sh
+tedge mqtt pub -r -q 2 'te/device/main///cmd/self_update/local-1' '{
+    "status": "init",
+    "image": "ghcr.io/thin-edge/tedge-container-bundle:$VERSION",
+    "containerName": "tedge",
+    "url": "http://192.168.1.10:8000/tedge-container-bundle.tar.gz"
+}'
+```
+
+Though when triggering the operation locally ensure that you clean up the operation after it is has completed using:
+
+```sh
+tedge mqtt pub -r -q 2 'te/device/main///cmd/self_update/local-1' ''
+```
+
+
+### Self update from an image file on an older image
+
+The workflow which installs the image from a url is part of the image itself, so a device
+still running an image from before this feature ignores the url and falls back to pulling
+from a container registry. Such a device can still be updated without registry access, by
+loading the image into the container engine first and then triggering an ordinary self
+update. Only the first update needs this, afterwards the url is handled by the device.
+
+The container engine keeps the loaded image, and the self update only pulls an image when
+the reference is not already present locally.
+
+1. Upload the archive to Cumulocity as described above, then read the binary id from the end
+   of the software version's url
+
+    ```sh
+    BINARY_ID=$(
+        c8y software versions list \
+            --software tedge \
+            --version "ghcr.io/thin-edge/tedge-container-bundle:$VERSION" \
+            --select c8y_Software.url \
+            -o csv \
+        | c8y template execute --template "local parts = std.split(input.value, '/'); parts[std.length(parts)-1]"
+    )
+    ```
+
+2. Load the image into the device's container engine using a shell operation
+
+    ```sh
+    DEVICE_ID="device01"
+    c8y operations create \
+        --device "$DEVICE_ID" \
+        --description "Load the tedge-container-bundle image" \
+        --template "{c8y_Command:{text:'tedge http get /c8y/inventory/binaries/$BINARY_ID > /tmp/tedge-container-bundle.tar.gz && sudo -E tedge-container engine docker load --input /tmp/tedge-container-bundle.tar.gz && rm -f /tmp/tedge-container-bundle.tar.gz'}}"
+    ```
+
+    `tedge http get` sends the request via the local Cumulocity proxy, so no credentials are
+    needed on the device. Make sure the device has enough free space for the archive.
+
+3. Install the version without a binary, as the image is already on the device
+
+    ```sh
+    c8y software versions install \
+        --device "$DEVICE_ID" \
+        --action install \
+        --software tedge \
+        --softwareType container \
+        --url " " \
+        --version "ghcr.io/thin-edge/tedge-container-bundle:$VERSION"
+    ```
+
+The same two steps work for any future version, as they only use the shell operation and
+the container engine, so they are a way out of any self update which cannot be performed by
+the image currently on the device.
+
+
 ### SSH Access
 
 **When to use it?**

--- a/files/tedge/self_update.toml
+++ b/files/tedge/self_update.toml
@@ -10,16 +10,35 @@ on_success = "executing"
 
 [executing]
 action = "proceed"
+on_success = "check_image_source"
+
+[check_image_source]
+# An image url is optional. Without it the image is pulled from a container registry
+script = "sh -c '[ -n \"$1\" ]' -- ${.payload.url}"
+on_exit.0 = "download_image"
+on_exit._ = "install_image"
+
+[download_image]
+action = "download"
+input.url = "${.payload.url}"
+on_success = "install_image"
+on_error = { status = "failed", reason = "Failed to download the container image" }
+
+[install_image]
+script = "sh -c 'sudo -E tedge-container tools image-install --image \"$1\" --file \"$2\"; rc=$?; rm -f \"$2\"; exit $rc' -- ${.payload.image} ${.payload.downloadedPath}"
 on_success = "needs_update"
+on_error = { status = "failed", reason = "Failed to install the container image" }
 
 [needs_update]
-script = "sudo -E tedge-container tools container-clone --image ${.payload.image} --container ${.payload.containerName} --check"
+# Only skip pulling when the image came from an archive, so that a registry based
+# update still picks up a new image published under the same tag
+script = "sh -c 'sudo -E tedge-container tools container-clone ${1:+--no-pull} --check --image \"$2\" --container \"$3\"' -- ${.payload.downloadedPath} ${.payload.image} ${.payload.containerName}"
 on_exit.0 = "update"
 on_exit.2 = "successful"
 on_exit._ = "failed"
 
 [update]
-script = "sudo -E tedge-container tools container-clone --fork --image ${.payload.image} --container ${.payload.containerName} --fork-name ${.payload.containerName}-updater --stop-after 10s"
+script = "sh -c 'sudo -E tedge-container tools container-clone ${1:+--no-pull} --fork --image \"$2\" --container \"$3\" --fork-name \"$3-updater\" --stop-after 10s' -- ${.payload.downloadedPath} ${.payload.image} ${.payload.containerName}"
 on_success = "wait-for-container-stop"
 on_error = "failed"
 
@@ -40,7 +59,9 @@ on_success = "verify"
 on_error = "verify"
 
 [verify]
-script = "sudo -E tedge-container tools container-clone --image ${.payload.image} --container ${.payload.containerName} --check"
+# Only skip pulling when the image came from an archive, so that a registry based
+# update still picks up a new image published under the same tag
+script = "sh -c 'sudo -E tedge-container tools container-clone ${1:+--no-pull} --check --image \"$2\" --container \"$3\"' -- ${.payload.downloadedPath} ${.payload.image} ${.payload.containerName}"
 # Expected 2 which means no update is required (as it should of already happened).
 # If an update is still required, then it generally means something unexpected happened
 on_exit.0 = { status = "failed", reason = "Container was not updated" }

--- a/files/tedge/software_update.toml
+++ b/files/tedge/software_update.toml
@@ -19,6 +19,7 @@ on_exit._ = "failed"
 operation = "self_update"
 input.image = "${.payload.image}"
 input.containerName = "${.payload.containerName}"
+input.url = "${.payload.url}"
 on_exec = "await-self-update"
 
 [await-self-update]

--- a/justfile
+++ b/justfile
@@ -101,6 +101,11 @@ build-test-bundles:
     echo "Building tedge-container-bundle images"
     just build "docker,dest=./tests/tedge-container-bundle_99.99.1.tar.gz" 99.99.1
     just build "docker,dest=./tests/tedge-container-bundle_99.99.2.tar.gz" 99.99.2
+    # Built to a separate directory so that it is not pre-loaded into the test device's
+    # container engine. It is uploaded to Cumulocity and installed from there instead
+    mkdir -p ./tests/images
+    just build "docker,dest=./tests/images/tedge-container-bundle_99.99.3.tar" 99.99.3
+    gzip -f ./tests/images/tedge-container-bundle_99.99.3.tar
 
 # Run tests
 test *ARGS='':

--- a/tests/main/self-update.robot
+++ b/tests/main/self-update.robot
@@ -48,6 +48,25 @@ Self update using software update operation
     # updater container should be removed (logs are already collected as part of the workflow)
     Cumulocity.Should Have Services    service_type=container    name=tedge-updater    min_count=0    max_count=0
 
+Self update using an image installed from a file
+    # pre-condition: the image is only available as a binary in Cumulocity, so any
+    # attempt to pull it from a container registry would fail
+    Device Should Have Installed Software
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}
+    ...    timeout=10
+
+    ${url}=    Cumulocity.Create Inventory Binary
+    ...    tedge-container-bundle
+    ...    image
+    ...    file=${CURDIR}/../images/tedge-container-bundle_99.99.3.tar.gz
+
+    ${operation}=    Cumulocity.Install Software
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.3", "softwareType": "container", "url": "${url}"}
+
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=240
+    Device Should Have Installed Software
+    ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.3", "softwareType": "container"}
+
 Rollback when trying to install a non-tedge based image
     # pre-condition
     Device Should Have Installed Software
@@ -81,7 +100,8 @@ Self update using software update operation using Container type
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.1", "softwareType": "container"}
     ...    timeout=10
     Device Should Not Have Installed Software
-    ...    {"name": "app20", "version": "ghcr.io/thin-edge/test-images/nginx:latest", "softwareType": "container"}    timeout=10
+    ...    {"name": "app20", "version": "ghcr.io/thin-edge/test-images/nginx:latest", "softwareType": "container"}
+    ...    timeout=10
 
     ${operation}=    Cumulocity.Install Software
     ...    {"name": "tedge", "version": "ghcr.io/thin-edge/tedge-container-bundle:99.99.2", "softwareType": "container"}


### PR DESCRIPTION
Closes #54

Requires `tedge-container-plugin-ng` >= 2.12.0 (released), which carries
thin-edge/tedge-container-plugin#228, thin-edge/tedge-container-plugin#229 and
thin-edge/tedge-container-plugin#230.

## What

The `self_update` operation now accepts an optional `url` pointing to a container image
archive (`docker save` / `podman save` output). When present, the archive is downloaded
and installed into the local container engine, and the update proceeds against the locally
available image instead of pulling it from a container registry.

This lets devices without registry access be updated from a binary attached to a software
version in Cumulocity.

## How

`self_update.toml` branches on whether `url` is set:

```
executing -> check_image_source -> download_image -> install_image -> needs_update -> ...
                              \----------------------^
```

* `download_image` uses the agent's builtin `download` action. For a Cumulocity software
  binary, the c8y mapper has already rewritten the url to the local auth proxy, so no
  extra credentials are needed.
* `install_image` calls `tedge-container tools image-install`, which loads the archive when
  one was downloaded and pulls from a registry otherwise. The archive is removed once
  installed, and `tedge-container tools container-clone` then skips its own pull because
  the image already exists in the engine's image store.
* `software_update.toml` passes the url through to `self_update`. The url itself comes from
  `tedge-container self check`, which now reports it.

Image acquisition is therefore a single step regardless of where the image comes from. That
also improves reporting: a registry failure used to surface from `needs_update`, whose
`on_exit._` carries no reason, which is why such a failure reached Cumulocity as
"Unknown reason". It now fails at `install_image` with a reason.

The clone steps are told not to pull only when the image came from an archive, keyed off
`downloadedPath` being set. A registry based update keeps its previous behaviour, so an
image published under a tag which already resolves locally, such as `latest`, is still
picked up when `container.alwaysPull` is enabled.

Without a `url` the workflow payload is unchanged and the image is still pulled from a
registry.

## Testing

* New system test `Self update using an image installed from a file` installs
  `tedge-container-bundle:99.99.3` from a Cumulocity binary. That tag is built into
  `tests/images/` and deliberately **not** pre-loaded into the test device's container
  engine, so the test would fail if a registry pull were attempted.
* Verified locally against a built image with the plugin branch: workflow definitions parse
  in `tedge-agent`; the `install_image` command run as the `tedge` user installs the image,
  removes the archive and propagates failures; `check_image_source` branches correctly on a
  present/absent url.
